### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/docs/Test_speed.md
+++ b/docs/Test_speed.md
@@ -1,6 +1,6 @@
 # Test speed
 
-This guidence explains how to reproduce speed results of YOLOv6. For fair comparision, the speed results do not contain the time cost of data pre-processing and NMS post-processing.
+This guidence explains how to reproduce speed results of YOLOv6. For fair comparison, the speed results do not contain the time cost of data pre-processing and NMS post-processing.
 
 ## 0. Prepare model
 

--- a/yolov6/core/evaler.py
+++ b/yolov6/core/evaler.py
@@ -105,7 +105,7 @@ class Evaler:
     def eval_model(self, pred_results, model, dataloader, task):
         '''Evaluate models
         For task speed, this function only evaluates the speed of model and outputs inference time.
-        For task val, this function evalutates the speed and mAP by pycocotools, and returns 
+        For task val, this function evaluates the speed and mAP by pycocotools, and returns 
         inference time and mAP value.
         '''
         LOGGER.info(f'\nEvaluating speed.')

--- a/yolov6/layers/common.py
+++ b/yolov6/layers/common.py
@@ -139,7 +139,7 @@ class RepVGGBlock(nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size=3,
                  stride=1, padding=1, dilation=1, groups=1, padding_mode='zeros', deploy=False, use_se=False):
         super(RepVGGBlock, self).__init__()
-        """ Intialization of the class.
+        """ Initialization of the class.
         Args:
             in_channels (int): Number of channels in the input image
             out_channels (int): Number of channels produced by the convolution

--- a/yolov6/utils/figure_iou.py
+++ b/yolov6/utils/figure_iou.py
@@ -13,7 +13,7 @@ class IOUloss:
             box_format: (string), must be one of 'xywh' or 'xyxy'.
             iou_type: (string), can be one of 'ciou', 'diou', 'giou' or 'siou'
             reduction: (string), specifies the reduction to apply to the output, must be one of 'none', 'mean','sum'.
-            eps: (float), a value to avoid devide by zero error.
+            eps: (float), a value to avoid divide by zero error.
         """
         self.box_format = box_format
         self.iou_type = iou_type.lower()


### PR DESCRIPTION
fixing typo on separated markdown and python replacing files to correct words with reference from [merriam webster dictionary spelling](https://www.merriam-webster.com/) and [oxford dictionary english](https://www.oed.com/)