### PR TITLE
feat: add options for eval interval and heavy eval range

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -26,7 +26,10 @@ def get_args_parser(add_help=True):
     parser.add_argument('--epochs', default=400, type=int, help='number of total epochs to run')
     parser.add_argument('--workers', default=8, type=int, help='number of data loading workers (default: 8)')
     parser.add_argument('--device', default='0', type=str, help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
-    parser.add_argument('--noval', action='store_true', help='only evaluate in final epoch')
+    parser.add_argument('--eval-interval', default=20, help='evaluate at every interval epochs')
+    parser.add_argument('--eval-final-only', action='store_true', help='only evaluate at the final epoch')
+    parser.add_argument('--heavy-eval-range', default=50,
+                        help='evaluating every epoch for last such epochs (can be jointly used with --eval-interval)')
     parser.add_argument('--check-images', action='store_true', help='check images when initializing datasets')
     parser.add_argument('--check-labels', action='store_true', help='check label files when initializing datasets')
     parser.add_argument('--output-dir', default='./runs/train', type=str, help='path to save outputs')

--- a/yolov6/core/engine.py
+++ b/yolov6/core/engine.py
@@ -98,9 +98,9 @@ class Trainer:
         self.update_optimizer()
 
     def eval_and_save(self):
-        epoch_sub = self.max_epoch - self.epoch
-        val_period = 20 if epoch_sub > 100 else 1 # to fasten training time, evaluate in every 20 epochs for the early stage.
-        is_val_epoch = (not self.args.noval or (epoch_sub == 1)) and (self.epoch % val_period == 0)
+        remaining_epochs = self.max_epoch - self.epoch
+        eval_interval = self.args.eval_interval if remaining_epochs > self.args.heavy_eval_range else 1
+        is_val_epoch = (not self.args.eval_final_only or (remaining_epochs == 1)) and (self.epoch % eval_interval == 0)
         if self.main_process:
             self.ema.update_attr(self.model, include=['nc', 'names', 'stride']) # update attributes for ema model
             if is_val_epoch:


### PR DESCRIPTION
Adding the following options:
```
  --eval-interval EVAL_INTERVAL
                        evaluate at every interval epochs
  --eval-final-only     only evaluate at the final epoch
  --heavy-eval-range HEAVY_EVAL_RANGE
                        evaluating every epoch for last such epochs (can be
                        jointly used with --eval-interval)
```
As a rule of thumb, for 300 epochs training of YOLOv6s, the best val mAP comes usually during last 20 epochs.