### PR TITLE
修复一个bug，当图片名字里面有.的时候会生成个空白生成标签json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
+.idea/
 .eggs/
 parts/
 sdist/

--- a/yolov6/data/datasets.py
+++ b/yolov6/data/datasets.py
@@ -194,6 +194,10 @@ class TrainValDataset(Dataset):
         for i, l in enumerate(label):
             l[:, 0] = i  # add target image index for build_targets()
         return torch.stack(img, 0), torch.cat(label, 0), path, shapes
+    def img2label_paths(self,img_paths):
+        # Define label paths as a function of image paths
+        sa, sb = f'{os.sep}images{os.sep}', f'{os.sep}labels{os.sep}'  # /images/, /labels/ substrings
+        return [sb.join(x.rsplit(sa, 1)).rsplit('.', 1)[0] + '.txt' for x in img_paths]
 
     def get_imgs_labels(self, img_dir):
 
@@ -249,10 +253,7 @@ class TrainValDataset(Dataset):
                     img_info
                 ), "No information in record files, please add option --check_images."
         img_paths = list(img_info.keys())
-        label_paths = [
-            osp.join(label_dir, osp.basename(p).split(".")[0] + ".txt")
-            for p in img_paths
-        ]
+        label_paths = self.img2label_paths(img_paths)
         if (
             self.check_labels or "labels" not in img_info[img_paths[0]]
         ):  # key 'labels' not saved in img_info


### PR DESCRIPTION
原来的标签使用的从.切分的方式只适用部分数据集，这导致很多人不能正常训练，因此修改了获取标签的方式
![image](https://user-images.githubusercontent.com/49591435/176550886-bb9ba69a-2a6c-4d27-84c3-b966298b41f1.png)
即使带有.名字的数据集也能正确获取标签，该类型数据集很多，数据集来自roboflow，这也是为什么绝大多数人map为0的原因。
合并之后有一点尤其重要，那就是删除原来生成的json文件和annotations文件夹