### PR TITLE
修复一个bug，当文件名中有额外的.时无法正确匹配标签

### DIFF
--- a/yolov6/data/datasets.py
+++ b/yolov6/data/datasets.py
@@ -195,6 +195,11 @@ class TrainValDataset(Dataset):
         for i, l in enumerate(label):
             l[:, 0] = i  # add target image index for build_targets()
         return torch.stack(img, 0), torch.cat(label, 0), path, shapes
+    def img2label_paths(self,img_paths):
+        # Define label paths as a function of image paths
+        sa, sb = f'{os.sep}images{os.sep}', f'{os.sep}labels{os.sep}'  # /images/, /labels/ substrings
+        return [sb.join(x.rsplit(sa, 1)).rsplit('.', 1)[0] + '.txt' for x in img_paths]
+
 
     def get_imgs_labels(self, img_dir):
 
@@ -256,10 +261,7 @@ class TrainValDataset(Dataset):
         assert osp.exists(label_dir), f"{label_dir} is an invalid directory path!"
 
         img_paths = list(img_info.keys())
-        label_paths = sorted(
-            osp.join(label_dir, osp.basename(p).split(".")[0] + ".txt")
-            for p in img_paths
-        )
+        label_paths = self.img2label_paths(img_paths)
         label_hash = self.get_hash(label_paths)
         if "label_hash" not in cache_info or cache_info["label_hash"] != label_hash:
             self.check_labels = True


### PR DESCRIPTION
这是为什么很多人map一直为0，没正确匹配标签的话导致标签是空的，所以无论怎么训练都是0
这种数据非常常见
![image](https://user-images.githubusercontent.com/49591435/176560407-a58e3b17-1886-4537-82e5-4ab351d35648.png)
修改后要删除生成的json文件和annotations文件夹