### PR TITLE
Run tools/infer.py on a video file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ python tools/infer.py --weights yolov6s.pt --source img.jpg / imgdir
                                 yolov6n.pt
 ```
 
+Additionally, you can run inference directly on a video file (note the additional `--video` flag at the end)
+```shell
+python tools/infer.py --weights yolov6s.pt --source video.mp4 --video
+                                yolov6n.pt
+```
+
 ### Training
 
 Single GPU

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 from yolov6.utils.events import LOGGER
-from yolov6.core.inferer import Inferer
+from yolov6.core.inferer import Inferer, VideoInferer
 
 
 def get_args_parser(add_help=True):
@@ -34,6 +34,7 @@ def get_args_parser(add_help=True):
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels.')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences.')
     parser.add_argument('--half', action='store_true', help='whether to use FP16 half-precision inference.')
+    parser.add_argument('--video', action='store_true', help='whether to use image based or video based inference engine')
 
     args = parser.parse_args()
     LOGGER.info(args)
@@ -57,6 +58,7 @@ def run(weights=osp.join(ROOT, 'yolov6s.pt'),
         hide_labels=False,
         hide_conf=False,
         half=False,
+        video=False
         ):
     """ Inference process
 
@@ -92,7 +94,8 @@ def run(weights=osp.join(ROOT, 'yolov6s.pt'),
         os.mkdir(osp.join(save_dir, 'labels'))
 
     # Inference
-    inferer = Inferer(source, weights, device, yaml, img_size, half)
+    infer_cls = Inferer if not video else VideoInferer
+    inferer = infer_cls(source, weights, device, yaml, img_size, half)
     inferer.infer(conf_thres, iou_thres, classes, agnostic_nms, max_det, save_dir, save_txt, save_img, hide_labels, hide_conf)
 
     if save_txt or save_img:


### PR DESCRIPTION
Added an ability to run inference directly on video files in `tools/infer.py` script. A video file can be passed through a `--source` flag, but users need to additionally specify `--video`. 

The `--video` flag can be omitted by checking the extension of `--source` file against a list of supported video extensions and setting it automatically if the extension matches. Let me know if this is something that should be added as well. 