### PR TITLE
fix spell mistake of LOGGER.warning

### DIFF
--- a/yolov6/core/inferer.py
+++ b/yolov6/core/inferer.py
@@ -102,7 +102,7 @@ class Inferer:
             img_src = cv2.imread(path)
             assert img_src is not None, f'Invalid image: {path}'
         except Exception as e:
-            LOGGER.Warning(e)
+            LOGGER.warning(e)
         image = letterbox(img_src, img_size, stride=stride)[0]
 
         # Convert


### PR DESCRIPTION
fix mistake spell in [/yolov6/core/inferer.py](https://github.com/meituan/YOLOv6/blob/af897f2aff07c7f46c97875e3657eb1968f1e1a1/yolov6/core/inferer.py#L101-L105) 
`Warning` to `warning`