### PR TITLE
Allows images to be in sub directories. Also added optional --save-di…

### DIFF
--- a/tools/infer.py
+++ b/tools/infer.py
@@ -27,6 +27,7 @@ def get_args_parser(add_help=True):
     parser.add_argument('--device', default='0', help='device to run our model i.e. 0 or 0,1,2,3 or cpu.')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt.')
     parser.add_argument('--save-img', action='store_false', help='save visuallized inference results.')
+    parser.add_argument('--save-dir', type=str, help='directory to save predictions in. See --save-txt.')
     parser.add_argument('--view-img', action='store_true', help='show inference results')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by classes, e.g. --classes 0, or --classes 0 2 3.')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS.')
@@ -51,6 +52,7 @@ def run(weights=osp.join(ROOT, 'yolov6s.pt'),
         device='',
         save_txt=False,
         save_img=True,
+        save_dir=None,
         view_img=True,
         classes=None,
         agnostic_nms=False,
@@ -82,13 +84,16 @@ def run(weights=osp.join(ROOT, 'yolov6s.pt'),
         half: Use FP16 half-precision inference, e.g. False
     """
     # create save dir
-    save_dir = osp.join(project, name)
+    if save_dir is None:
+        save_dir = osp.join(project, name)
+        save_txt_path = osp.join(save_dir, 'labels')
+    else:
+        save_txt_path = save_dir
     if (save_img or save_txt) and not osp.exists(save_dir):
         os.makedirs(save_dir)
     else:
         LOGGER.warning('Save directory already existed')
     if save_txt:
-        save_txt_path = osp.join(save_dir, 'labels')
         if not osp.exists(save_txt_path):
             os.makedirs(save_txt_path)
 

--- a/yolov6/core/inferer.py
+++ b/yolov6/core/inferer.py
@@ -47,6 +47,7 @@ class Inferer:
 
         # Load data
         self.files = LoadData(source)
+        self.source = source
 
         # Switch model to deploy status
         self.model_switch(self.model.model, self.img_size)
@@ -75,8 +76,11 @@ class Inferer:
             det = non_max_suppression(pred_results, conf_thres, iou_thres, classes, agnostic_nms, max_det=max_det)[0]
             t2 = time.time()
 
-            save_path = osp.join(save_dir, osp.basename(img_path))  # im.jpg
-            txt_path = osp.join(save_dir, 'labels', osp.splitext(osp.basename(img_path))[0])
+            # Create output files in nested dirs that mirrors the structure of the images' dirs
+            rel_path = osp.relpath(osp.dirname(img_path), self.source)
+            save_path = osp.join(save_dir, rel_path, osp.basename(img_path))  # im.jpg
+            txt_path = osp.join(save_dir, rel_path, osp.splitext(osp.basename(img_path))[0])
+            os.makedirs(osp.join(save_dir, rel_path), exist_ok=True)
 
             gn = torch.tensor(img_src.shape)[[1, 0, 1, 0]]  # normalization gain whwh
             img_ori = img_src.copy()

--- a/yolov6/data/datasets.py
+++ b/yolov6/data/datasets.py
@@ -206,9 +206,9 @@ class TrainValDataset(Dataset):
         )
         NUM_THREADS = min(8, os.cpu_count())
 
-        img_paths = glob.glob(osp.join(img_dir, "*"), recursive=True)
+        img_paths = glob.glob(osp.join(img_dir, "**/*"), recursive=True)
         img_paths = sorted(
-            p for p in img_paths if p.split(".")[-1].lower() in IMG_FORMATS
+            p for p in img_paths if p.split(".")[-1].lower() in IMG_FORMATS and os.path.isfile(p)
         )
         assert img_paths, f"No images found in {img_dir}."
 
@@ -257,9 +257,14 @@ class TrainValDataset(Dataset):
         )
         assert osp.exists(label_dir), f"{label_dir} is an invalid directory path!"
 
+        # Look for labels in the save relative dir that the images are in
+        def _new_rel_path_with_ext(base_path: str, full_path: str, new_ext: str):
+            rel_path = osp.relpath(full_path, base_path)
+            return osp.join(osp.dirname(rel_path), osp.splitext(osp.basename(rel_path))[0] + new_ext)
+
         img_paths = list(img_info.keys())
         label_paths = sorted(
-            osp.join(label_dir, osp.splitext(osp.basename(p))[0] + ".txt")
+            osp.join(label_dir, _new_rel_path_with_ext(img_dir, p, ".txt"))
             for p in img_paths
         )
         label_hash = self.get_hash(label_paths)
@@ -554,7 +559,7 @@ class LoadData:
     def __init__(self, path):
         p = str(Path(path).resolve())  # os-agnostic absolute path
         if os.path.isdir(p):
-            files = sorted(glob.glob(os.path.join(p, '*.*')))  # dir
+            files = sorted(glob.glob(os.path.join(p, '**/*.*'), recursive=True))  # dir
         elif os.path.isfile(p):
             files = [p]  # files
         else:


### PR DESCRIPTION
Allows images to be in sub directories. This makes it much easier to train on images from multiple datasets where each dataset is in its own dir.
Also added optional --save-dir to infer.py to allow customization of output file locations by that script.
Both of these capabilities are supported in yolov5 and are useful for yolov6 as well.