### PR TITLE
fix: remove redundant contents in config

### DIFF
--- a/configs/repopt/yolov6s_hs.py
+++ b/configs/repopt/yolov6s_hs.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='siou'
     )

--- a/configs/repopt/yolov6s_opt.py
+++ b/configs/repopt/yolov6s_opt.py
@@ -19,9 +19,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='siou'
     )

--- a/configs/yolov6_tiny.py
+++ b/configs/yolov6_tiny.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='ciou'
     )

--- a/configs/yolov6_tiny_finetune.py
+++ b/configs/yolov6_tiny_finetune.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='ciou'
     )

--- a/configs/yolov6n.py
+++ b/configs/yolov6n.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='ciou'
     )

--- a/configs/yolov6n_finetune.py
+++ b/configs/yolov6n_finetune.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='ciou'
     )

--- a/configs/yolov6s.py
+++ b/configs/yolov6s.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='siou'
     )

--- a/configs/yolov6s_finetune.py
+++ b/configs/yolov6s_finetune.py
@@ -18,9 +18,7 @@ model = dict(
         type='EffiDeHead',
         in_channels=[128, 256, 512],
         num_layers=3,
-        begin_indices=24,
         anchors=1,
-        out_indices=[17, 20, 23],
         strides=[8, 16, 32],
         iou_type='siou'
     )

--- a/yolov6/models/yolo.py
+++ b/yolov6/models/yolo.py
@@ -22,11 +22,7 @@ class Model(nn.Module):
         self.backbone, self.neck, self.detect = build_network(config, channels, num_classes, anchors, num_layers)
 
         # Init Detect head
-        begin_indices = config.model.head.begin_indices
-        out_indices_head = config.model.head.out_indices
         self.stride = self.detect.stride
-        self.detect.i = begin_indices
-        self.detect.f = out_indices_head
         self.detect.initialize_biases()
 
         # Init weights


### PR DESCRIPTION
Remove redundant contents in config to keey config clean.