### PR TITLE
Update figure_iou.py

### DIFF
--- a/yolov6/utils/figure_iou.py
+++ b/yolov6/utils/figure_iou.py
@@ -83,6 +83,8 @@ class IOUloss:
             loss = loss.sum()
         elif self.reduction == 'mean':
             loss = loss.mean()
+            
+        loss = torch.nan_to_num(loss)
 
         return loss
 


### PR DESCRIPTION
As mentioned in issue [#319] (https://github.com/meituan/YOLOv6/issues/319), sometimes during training the IOU loss gets stuck at nan. [@qinhao14 ] (https://github.com/qinhao14) suggested to use the function torch.nan_to_num() and it did solve the problem for me. And after multiple training sessions, no new problem seems to have arisen because of this.