### PR TITLE
Add YOLOv6 quantization and auto compression example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Your can also specify a checkpoint path to `--resume` parameter by
 *  [ONNX](./deploy/ONNX)
 *  [OpenCV Python/C++](./deploy/ONNX/OpenCV)
 *  [OpenVINO](./deploy/OpenVINO)
+*  [Quantization and Auto Compression](./tools/auto_compression)
 *  [Partial Quantization](./tools/partial_quantization)
 *  [TensorRT](./deploy/TensorRT)
 
@@ -134,7 +135,7 @@ Your can also specify a checkpoint path to `--resume` parameter by
  * YOLOv6 ONNXRuntime/MNN/TNN C++: [YOLOv6-ORT](https://github.com/DefTruth/lite.ai.toolkit/blob/main/lite/ort/cv/yolov6.cpp), [YOLOv6-MNN](https://github.com/DefTruth/lite.ai.toolkit/blob/main/lite/mnn/cv/mnn_yolov6.cpp) and [YOLOv6-TNN](https://github.com/DefTruth/lite.ai.toolkit/blob/main/lite/tnn/cv/tnn_yolov6.cpp) from [DefTruth](https://github.com/DefTruth)
  * YOLOv6 TensorRT Python: [yolov6-tensorrt-python](https://github.com/Linaom1214/tensorrt-python/blob/main/yolov6/trt.py) from [Linaom1214](https://github.com/Linaom1214)
  * YOLOv6 TensorRT Windows C++: [yolort](https://github.com/zhiqwang/yolov5-rt-stack/tree/main/deployment/tensorrt-yolov6) from [Wei Zeng](https://github.com/Wulingtian)
- * YOLOv6 Quantization and Auto Compression Example [YOLOv6-ACT](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/auto_compression/pytorch_yolov6) from [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim)
+ * YOLOv6 Quantization and Auto Compression Example [YOLOv6-ACT](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/auto_compression/pytorch_yolo_series) from [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim)
  * [YOLOv6 web demo](https://huggingface.co/spaces/nateraw/yolov6) on [Huggingface Spaces](https://huggingface.co/spaces) with [Gradio](https://github.com/gradio-app/gradio). [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/nateraw/yolov6)
  * Tutorial: [How to train YOLOv6 on a custom dataset](https://blog.roboflow.com/how-to-train-yolov6-on-a-custom-dataset/) <a href="https://colab.research.google.com/drive/1YnbqOinBZV-c9I7fk_UL6acgnnmkXDMM"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
  * Demo of YOLOv6 inference on Google Colab [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mahdilamb/YOLOv6/blob/main/inference.ipynb)

--- a/tools/auto_compression/README.md
+++ b/tools/auto_compression/README.md
@@ -1,0 +1,148 @@
+# YOLOv6 Quantization Compression Example
+
+This example uses [ACT](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/auto_compression) from [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim) for YOLOv6 quantization.
+The quantized model can be deployed on TensorRT.
+
+- Benchmark
+
+| Model | Base mAP<sup>val<br>0.5:0.95  | Quant mAP<sup>val<br>0.5:0.95 | Latency<sup><small>FP32</small><sup><br><sup> | Latency<sup><small>FP16</small><sup><br><sup> | Latency<sup><small>INT8</small><sup><br><sup> | Model |
+| :-------- |:-------- |:--------: | :--------: | :---------------------: | :----------------: | :----------------: |
+| YOLOv6s |  42.4   | 41.3  |  9.06ms  |   2.90ms   |  **1.83ms**  | [ONNX](https://github.com/meituan/YOLOv6/releases/download/0.1.0/yolov6s.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov6s_quant_onnx.tar) |
+| YOLOv6-Tiny  |  40.8   | 39.0 |  5.06ms  |   2.32ms   |  **1.68ms** | [ONNX](https://github.com/meituan/YOLOv6/releases/download/0.1.0/yolov6t.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov6_tiny_quant_onnx.tar) |
+
+Note:
+- The mAP are evaluated in the COCO val2017, and fixed 640*640 size.
+- The test environment is: Tesla T4, TensorRT 8.4.1, and batch_size=1.
+
+### Experiment
+
+You also can enter the [YOLOv6_quantization_act.ipynb](./YOLOv6_quantization_act.ipynb) to experiment.
+
+#### 1. Environment Dependencies Installation
+
+- paddlepaddle>=2.3.2
+- paddleslim>=2.3.4
+- pycocotools
+
+```shell
+# Take Ubuntu and CUDA 11.2 as an example for GPU, and other environments can be installed directly according to Paddle's official website.
+#  https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/install/pip/linux-pip.html
+python -m pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+
+# CPU
+#pip install paddlepaddle==2.3.2
+
+pip install paddleslim==2.3.4
+```
+
+#### 2. Prepare the dataset
+
+**Choose one of (1) or (2) to prepare the data.**
+
+- (1) Support unlabeled pictures, directly set the picture folder, but does not support the mAP evaluation.
+
+  Modify the `image_path` path in [config](./configs) of the real prediction scenario.
+  ```yaml
+  Global:
+    image_path: dataset/coco/val2017
+  ```
+
+- (2) Support loading COCO format dataset, **support the mAP evaluation.**
+
+  You can download [Train](http://images.cocodataset.org/zips/train2017.zip), [Val](http://images.cocodataset.org/zips/val2017.zip), [annotation](http://images.cocodataset.org/annotations/annotations_trainval2017.zip).
+
+  The directory format is as follows:
+  ```
+  dataset/coco/
+  ├── annotations
+  │   ├── instances_train2017.json
+  │   ├── instances_val2017.json
+  │   |   ...
+  ├── train2017
+  │   ├── 000000000009.jpg
+  │   ├── 000000580008.jpg
+  │   |   ...
+  ├── val2017
+  │   ├── 000000000139.jpg
+  │   ├── 000000000285.jpg
+  ```
+
+  If it is a custom data set, please prepare the data according to the above COCO data format.
+
+  After preparing the dataset, modify the `coco_dataset_dir` path in [config](./configs).
+  ```yaml
+  Global:
+    coco_dataset_dir: dataset/coco/
+    coco_train_image_dir: train2017
+    coco_train_anno_path: annotations/instances_train2017.json
+    coco_val_image_dir: val2017
+    coco_val_anno_path: annotations/instances_val2017.json
+  ```
+
+
+#### 3. Prepare the ONNX model
+
+The ONNX model can be prepared through the [Export Tutorial](https://github.com/meituan/YOLOv6/blob/main/deploy/ONNX/README.md). You can also download [yolov6s.onnx](https://github.com/meituan/YOLOv6/releases/download/0.1.0/yolov6s.onnx).
+
+The model without NMS is currently supported, and the end2end model will be supported in the future.
+
+
+#### 4. Auto compression
+
+- Single card training:
+```
+export CUDA_VISIBLE_DEVICES=0
+python run.py --config_path=./configs/yolov6s_qat_dis.yaml --save_dir='./output/'
+```
+
+- Distributed training:
+```
+CUDA_VISIBLE_DEVICES=0,1,2,3 python -m paddle.distributed.launch --log_dir=log --gpus 0,1,2,3 run.py \
+          --config_path=./configs/yolov6s_qat_dis.yaml --save_dir='./output/'
+```
+
+
+#### 5. Deployment
+
+After executing the program, output files will be generated in the output folder as shown below:
+```shell
+├── model.pdiparams         # Paddle prediction model weights
+├── model.pdmodel           # Paddle prediction model file
+├── calibration_table.txt   # Paddle calibration table after quantification
+├── ONNX
+│   ├── quant_model.onnx      # ONNX model after quantization
+│   ├── calibration.cache     # TensorRT can directly load the calibration table
+```
+
+##### Deploy with TensorRT
+
+Load `quant_model.onnx` and `calibration.cache`, you can directly use the TensorRT test script to verify, the detailed code can refer to [TensorRT deployment](/TensorRT)
+
+- Python test：
+```shell
+cd TensorRT
+python trt_eval.py --onnx_model_file=output/ONNX/quant_model.onnx \
+                   --calibration_file=output/ONNX/calibration.cache \
+                   --image_file=image.jpg \
+                   --precision_mode=int8
+```
+
+- Speed test
+```shell
+trtexec --onnx=output/ONNX/quant_model.onnx --avgRuns=1000 --workspace=1024 --calib=output/ONNX/calibration.cache --int8
+```
+
+##### Deploy with Paddle TensorRT
+
+- Python test:
+
+First install the [PaddlePaddle with TensorRT](https://www.paddlepaddle.org.cn/inference/v2.3/user_guides/download_lib.html#python).
+
+Then use [paddle_trt_infer.py](./paddle_trt_infer.py) to deploy:
+```shell
+python paddle_trt_infer.py --model_path=output --image_file=image.jpg --benchmark=True --run_mode=trt_int8
+```
+
+#### 6.FAQ
+
+- If you want to quantize the model with PTQ, you can use the [YOLOv6 PTQ example](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/post_training_quantization/pytorch_yolo_series).

--- a/tools/auto_compression/TensorRT/README.md
+++ b/tools/auto_compression/TensorRT/README.md
@@ -1,0 +1,37 @@
+# TensorRT Python deployment
+
+### Evaluation COCO mAP
+
+- FP16
+```shell
+python trt_eval.py --onnx_model_file=yolov6s.onnx \
+                   --precision_mode=fp16 \
+                   --dataset_dir=dataset/coco/ \
+                   --val_image_dir=val2017 \
+                   --val_anno_path=annotations/instances_val2017.json
+```
+
+- INT8
+```shell
+python trt_eval.py --onnx_model_file=yolov6s_quant_onnx/quant_model.onnx \
+                   --calibration_file=yolov6s_quant_onnx/calibration.cache \
+                   --precision_mode=int8 \
+                   --dataset_dir=dataset/coco/ \
+                   --val_image_dir=val2017 \
+                   --val_anno_path=annotations/instances_val2017.json
+```
+
+### Test a single image
+
+- FP16
+```shell
+python trt_eval.py --onnx_model_file=yolov6s-tiny.onnx --image_file=image.jpg --precision_mode=fp16
+```
+
+- INT8
+```shell
+python trt_eval.py --onnx_model_file=yolov6s_quant_onnx/quant_model.onnx \
+                   --calibration_file=yolov6s_quant_onnx/calibration.cache \
+                   --image_file=image.jpg \
+                   --precision_mode=int8
+```

--- a/tools/auto_compression/TensorRT/trt_backend.py
+++ b/tools/auto_compression/TensorRT/trt_backend.py
@@ -1,0 +1,250 @@
+import tensorrt as trt
+import pycuda.driver as cuda
+import pycuda.autoinit
+import sys
+import os
+import copy
+import numpy as np
+
+EXPLICIT_BATCH = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+EXPLICIT_PRECISION = 1 << (
+    int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_PRECISION)
+
+
+class LoadCalibrator(trt.IInt8EntropyCalibrator2):
+    def __init__(self, cache_file="calibration.cache"):
+        super().__init__()
+        self.cache_file = cache_file
+
+    def get_batch_size(self):
+        return 1
+
+    def read_calibration_cache(self):
+        # If there is a cache, use it instead of calibrating again. Otherwise, implicitly return None.
+        if os.path.exists(self.cache_file):
+            with open(self.cache_file, "rb") as f:
+                print("Using calibration cache to save time: {:}".format(
+                    self.cache_file))
+                return f.read()
+
+
+def remove_initializer_from_input(ori_model):
+    model = copy.deepcopy(ori_model)
+    if model.ir_version < 4:
+        print(
+            'Model with ir_version below 4 requires to include initilizer in graph input'
+        )
+        return
+
+    inputs = model.graph.input
+    name_to_input = {}
+    for input in inputs:
+        name_to_input[input.name] = input
+
+    for initializer in model.graph.initializer:
+        if initializer.name in name_to_input:
+            inputs.remove(name_to_input[initializer.name])
+    return model
+
+
+# Simple helper data class that's a little nicer to use than a 2-tuple.
+class HostDeviceMem(object):
+    def __init__(self, host_mem, device_mem):
+        self.host = host_mem
+        self.device = device_mem
+        if host_mem:
+            self.nbytes = host_mem.nbytes
+        else:
+            self.nbytes = 0
+
+    def __str__(self):
+        return "Host:\n" + str(self.host) + "\nDevice:\n" + str(self.device)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class TrtEngine:
+    def __init__(self,
+                 onnx_model_file,
+                 shape_info=None,
+                 max_batch_size=None,
+                 precision_mode="fp32",
+                 engine_file_path=None,
+                 calibration_cache_file="calibration.cache",
+                 verbose=False):
+        self.max_batch_size = 1 if max_batch_size is None else max_batch_size
+        precision_mode = precision_mode.lower()
+        assert precision_mode in [
+            "fp32", "fp16", "int8"
+        ], "precision_mode must be fp32, fp16 or int8, but your precision_mode is: {}".format(
+            precision_mode)
+        use_int8 = precision_mode == "int8"
+        use_fp16 = precision_mode == "fp16"
+        TRT_LOGGER = trt.Logger()
+        if verbose:
+            TRT_LOGGER = trt.Logger(trt.Logger.VERBOSE)
+        if engine_file_path is not None and os.path.exists(engine_file_path):
+            # If a serialized engine exists, use it instead of building an engine.
+            print("[TRT Backend] Reading engine from file {}".format(
+                engine_file_path))
+            with open(engine_file_path,
+                      "rb") as f, trt.Runtime(TRT_LOGGER) as runtime:
+                self.engine = runtime.deserialize_cuda_engine(f.read())
+        else:
+            builder = trt.Builder(TRT_LOGGER)
+            config = builder.create_builder_config()
+            network = None
+
+            if use_int8 and not builder.platform_has_fast_int8:
+                print("[TRT Backend] INT8 not supported on this platform.")
+            if use_fp16 and not builder.platform_has_fast_fp16:
+                print("[TRT Backend] FP16 not supported on this platform.")
+
+            if use_int8 and builder.platform_has_fast_int8:
+                print("[TRT Backend] Use INT8.")
+                network = builder.create_network(EXPLICIT_BATCH |
+                                                 EXPLICIT_PRECISION)
+                config.int8_calibrator = LoadCalibrator(calibration_cache_file)
+                config.set_flag(trt.BuilderFlag.INT8)
+            elif use_fp16 and builder.platform_has_fast_fp16:
+                print("[TRT Backend] Use FP16.")
+                network = builder.create_network(EXPLICIT_BATCH)
+                config.set_flag(trt.BuilderFlag.FP16)
+            else:
+                print("[TRT Backend] Use FP32.")
+                network = builder.create_network(EXPLICIT_BATCH)
+            parser = trt.OnnxParser(network, TRT_LOGGER)
+            runtime = trt.Runtime(TRT_LOGGER)
+            config.max_workspace_size = 1 << 28
+
+            import onnx
+            print("[TRT Backend] Loading ONNX model ...")
+            onnx_model = onnx_model_file
+            if not isinstance(onnx_model_file, onnx.ModelProto):
+                onnx_model = onnx.load(onnx_model_file)
+            onnx_model = remove_initializer_from_input(onnx_model)
+            if not parser.parse(onnx_model.SerializeToString()):
+                for error in range(parser.num_errors):
+                    print(parser.get_error(error))
+                raise Exception("ERROR: Failed to parse the ONNX file.")
+
+            if shape_info is None:
+                builder.max_batch_size = 1
+                for i in range(len(onnx_model.graph.input)):
+                    input_shape = [
+                        x.dim_value
+                        for x in onnx_model.graph.input[0]
+                        .type.tensor_type.shape.dim
+                    ]
+                    for s in input_shape:
+                        assert s > 0, "In static shape mode, the input of onnx model should be fixed, but now it's {}".format(
+                            onnx_model.graph.input[i])
+            else:
+                max_batch_size = 1
+                if shape_info is not None:
+                    assert len(
+                        shape_info
+                    ) == network.num_inputs, "Length of shape_info: {} is not same with length of model input: {}".format(
+                        len(shape_info), network.num_inputs)
+                    profile = builder.create_optimization_profile()
+                    for k, v in shape_info.items():
+                        if v[2][0] > max_batch_size:
+                            max_batch_size = v[2][0]
+                        print("[TRT Backend] optimize shape: ", k, v[0], v[1],
+                              v[2])
+                        profile.set_shape(k, v[0], v[1], v[2])
+                    config.add_optimization_profile(profile)
+                if max_batch_size > self.max_batch_size:
+                    self.max_batch_size = max_batch_size
+                builder.max_batch_size = self.max_batch_size
+
+            print("[TRT Backend] Completed parsing of ONNX file.")
+            print(
+                "[TRT Backend] Building an engine from onnx model may take a while..."
+            )
+            plan = builder.build_serialized_network(network, config)
+            print("[TRT Backend] Start Creating Engine.")
+            self.engine = runtime.deserialize_cuda_engine(plan)
+            print("[TRT Backend] Completed Creating Engine.")
+            if engine_file_path is not None:
+                with open(engine_file_path, "wb") as f:
+                    f.write(self.engine.serialize())
+
+        self.context = self.engine.create_execution_context()
+        if shape_info is not None:
+            self.context.active_optimization_profile = 0
+        self.stream = cuda.Stream()
+        self.bindings = []
+        self.inputs = []
+        self.outputs = []
+        for binding in self.engine:
+            self.bindings.append(0)
+            if self.engine.binding_is_input(binding):
+                self.inputs.append(HostDeviceMem(None, None))
+            else:
+                self.outputs.append(HostDeviceMem(None, None))
+
+        print("[TRT Backend] Completed TrtEngine init ...")
+
+    def infer(self, input_data):
+        assert len(self.inputs) == len(
+            input_data
+        ), "Length of input_data: {} is not same with length of input: {}".format(
+            len(input_data), len(self.inputs))
+
+        self.allocate_buffers(input_data)
+
+        return self.do_inference_v2(
+            self.context,
+            bindings=self.bindings,
+            inputs=self.inputs,
+            outputs=self.outputs,
+            stream=self.stream)
+
+    def do_inference_v2(self, context, bindings, inputs, outputs, stream):
+        # Transfer input data to the GPU.
+        [cuda.memcpy_htod_async(inp.device, inp.host, stream) for inp in inputs]
+        # Run inference.
+        context.execute_async_v2(bindings=bindings, stream_handle=stream.handle)
+        # Transfer predictions back from the GPU.
+        [
+            cuda.memcpy_dtoh_async(out.host, out.device, stream)
+            for out in outputs
+        ]
+        # Synchronize the stream
+        stream.synchronize()
+        # Return only the host outputs.
+        return [out.host for out in outputs]
+
+    def allocate_buffers(self, input_data):
+        input_idx = 0
+        output_idx = 0
+        for binding in self.engine:
+            idx = self.engine.get_binding_index(binding)
+            if self.engine.binding_is_input(binding):
+                if not input_data[input_idx].flags['C_CONTIGUOUS']:
+                    input_data[input_idx] = np.ascontiguousarray(input_data[
+                        input_idx])
+                self.context.set_binding_shape(idx,
+                                               (input_data[input_idx].shape))
+                self.inputs[input_idx].host = input_data[input_idx]
+                nbytes = input_data[input_idx].nbytes
+                if self.inputs[input_idx].nbytes < nbytes:
+                    self.inputs[input_idx].nbytes = nbytes
+                    self.inputs[input_idx].device = cuda.mem_alloc(nbytes)
+                    self.bindings[idx] = int(self.inputs[input_idx].device)
+                input_idx += 1
+            else:
+                dtype = trt.nptype(self.engine.get_binding_dtype(binding))
+                shape = self.context.get_binding_shape(idx)
+                self.outputs[output_idx].host = np.ascontiguousarray(
+                    np.empty(
+                        shape, dtype=dtype))
+                nbytes = self.outputs[output_idx].host.nbytes
+                if self.outputs[output_idx].nbytes < nbytes:
+                    self.outputs[output_idx].nbytes = nbytes
+                    self.outputs[output_idx].device = cuda.mem_alloc(
+                        self.outputs[output_idx].host.nbytes)
+                    self.bindings[idx] = int(self.outputs[output_idx].device)
+                output_idx += 1

--- a/tools/auto_compression/TensorRT/trt_eval.py
+++ b/tools/auto_compression/TensorRT/trt_eval.py
@@ -1,0 +1,307 @@
+import warnings
+warnings.filterwarnings("ignore")
+import os
+import sys
+import numpy as np
+import argparse
+from tqdm import tqdm
+import pkg_resources as pkg
+import time
+import cv2
+
+import paddle
+import onnx
+
+sys.path.append("../")
+from post_process import YOLOPostProcess, coco_metric
+from dataset import COCOValDataset
+import trt_backend
+
+
+def argsparser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--onnx_model_file',
+        type=str,
+        default='yolov6s_quant_onnx/quant_model.onnx',
+        help="onnx model file path.")
+    parser.add_argument(
+        '--calibration_file',
+        type=str,
+        default='yolov6s_quant_onnx/calibration.cache',
+        help="quant onnx model calibration cache file.")
+    parser.add_argument(
+        '--image_file',
+        type=str,
+        default=None,
+        help="image path, if set image_file, it will not eval coco.")
+    parser.add_argument(
+        '--dataset_dir',
+        type=str,
+        default='dataset/coco',
+        help="COCO dataset dir.")
+    parser.add_argument(
+        '--val_image_dir',
+        type=str,
+        default='val2017',
+        help="COCO dataset val image dir.")
+    parser.add_argument(
+        '--val_anno_path',
+        type=str,
+        default='annotations/instances_val2017.json',
+        help="COCO dataset anno path.")
+    parser.add_argument(
+        '--precision_mode',
+        type=str,
+        default='fp32',
+        help="support fp32/fp16/int8.")
+    parser.add_argument(
+        '--batch_size', type=int, default=1, help="Batch size of model input.")
+
+    return parser
+
+
+# load coco labels
+CLASS_LABEL = [
+    "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train",
+    "truck", "boat", "traffic light", "fire hydrant", "stop sign",
+    "parking meter", "bench", "bird", "cat", "dog", "horse", "sheep", "cow",
+    "elephant", "bear", "zebra", "giraffe", "backpack", "umbrella", "handbag",
+    "tie", "suitcase", "frisbee", "skis", "snowboard", "sports ball", "kite",
+    "baseball bat", "baseball glove", "skateboard", "surfboard",
+    "tennis racket", "bottle", "wine glass", "cup", "fork", "knife", "spoon",
+    "bowl", "banana", "apple", "sandwich", "orange", "broccoli", "carrot",
+    "hot dog", "pizza", "donut", "cake", "chair", "couch", "potted plant",
+    "bed", "dining table", "toilet", "tv", "laptop", "mouse", "remote",
+    "keyboard", "cell phone", "microwave", "oven", "toaster", "sink",
+    "refrigerator", "book", "clock", "vase", "scissors", "teddy bear",
+    "hair drier", "toothbrush"
+]
+
+
+def preprocess(image, input_size, mean=None, std=None, swap=(2, 0, 1)):
+    if len(image.shape) == 3:
+        padded_img = np.ones((input_size[0], input_size[1], 3)) * 114.0
+    else:
+        padded_img = np.ones(input_size) * 114.0
+    img = np.array(image)
+    r = min(input_size[0] / img.shape[0], input_size[1] / img.shape[1])
+    resized_img = cv2.resize(
+        img,
+        (int(img.shape[1] * r), int(img.shape[0] * r)),
+        interpolation=cv2.INTER_LINEAR, ).astype(np.float32)
+    padded_img[:int(img.shape[0] * r), :int(img.shape[1] * r)] = resized_img
+
+    padded_img = padded_img[:, :, ::-1]
+    padded_img /= 255.0
+    if mean is not None:
+        padded_img -= mean
+    if std is not None:
+        padded_img /= std
+    padded_img = padded_img.transpose(swap)
+    padded_img = np.ascontiguousarray(padded_img, dtype=np.float32)
+    return padded_img, r
+
+
+def get_color_map_list(num_classes):
+    color_map = num_classes * [0, 0, 0]
+    for i in range(0, num_classes):
+        j = 0
+        lab = i
+        while lab:
+            color_map[i * 3] |= (((lab >> 0) & 1) << (7 - j))
+            color_map[i * 3 + 1] |= (((lab >> 1) & 1) << (7 - j))
+            color_map[i * 3 + 2] |= (((lab >> 2) & 1) << (7 - j))
+            j += 1
+            lab >>= 3
+    color_map = [color_map[i:i + 3] for i in range(0, len(color_map), 3)]
+    return color_map
+
+
+def draw_box(img, boxes, scores, cls_ids, conf=0.5, class_names=None):
+    color_list = get_color_map_list(len(class_names))
+    for i in range(len(boxes)):
+        box = boxes[i]
+        cls_id = int(cls_ids[i])
+        color = tuple(color_list[cls_id])
+        score = scores[i]
+        if score < conf:
+            continue
+        x0 = int(box[0])
+        y0 = int(box[1])
+        x1 = int(box[2])
+        y1 = int(box[3])
+
+        text = '{}:{:.1f}%'.format(class_names[cls_id], score * 100)
+        font = cv2.FONT_HERSHEY_SIMPLEX
+
+        txt_size = cv2.getTextSize(text, font, 0.4, 1)[0]
+        cv2.rectangle(img, (x0, y0), (x1, y1), color, 2)
+        cv2.rectangle(img, (x0, y0 + 1),
+                      (x0 + txt_size[0] + 1, y0 + int(1.5 * txt_size[1])),
+                      color, -1)
+        cv2.putText(
+            img,
+            text, (x0, y0 + txt_size[1]),
+            font,
+            0.8, (0, 255, 0),
+            thickness=2)
+
+    return img
+
+
+def get_current_memory_mb():
+    """
+    It is used to Obtain the memory usage of the CPU and GPU during the running of the program.
+    And this function Current program is time-consuming.
+    """
+    try:
+        pkg.require('pynvml')
+    except:
+        from pip._internal import main
+        main(['install', 'pynvml'])
+    try:
+        pkg.require('psutil')
+    except:
+        from pip._internal import main
+        main(['install', 'psutil'])
+    try:
+        pkg.require('GPUtil')
+    except:
+        from pip._internal import main
+        main(['install', 'GPUtil'])
+    import pynvml
+    import psutil
+    import GPUtil
+    gpu_id = int(os.environ.get('CUDA_VISIBLE_DEVICES', 0))
+
+    pid = os.getpid()
+    p = psutil.Process(pid)
+    info = p.memory_full_info()
+    cpu_mem = info.uss / 1024. / 1024.
+    gpu_mem = 0
+    gpu_percent = 0
+    gpus = GPUtil.getGPUs()
+    if gpu_id is not None and len(gpus) > 0:
+        gpu_percent = gpus[gpu_id].load
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        meminfo = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        gpu_mem = meminfo.used / 1024. / 1024.
+    return round(cpu_mem, 4), round(gpu_mem, 4)
+
+
+def load_trt_engine():
+    model = onnx.load(FLAGS.onnx_model_file)
+    model_name = os.path.split(FLAGS.onnx_model_file)[-1].rstrip('.onnx')
+    if FLAGS.precision_mode == "int8":
+        engine_file = "{}_quant_model.trt".format(model_name)
+        assert os.path.exists(FLAGS.calibration_file)
+        trt_engine = trt_backend.TrtEngine(
+            model,
+            max_batch_size=1,
+            precision_mode=FLAGS.precision_mode,
+            engine_file_path=engine_file,
+            calibration_cache_file=FLAGS.calibration_file)
+    else:
+        engine_file = "{}_{}_model.trt".format(model_name, FLAGS.precision_mode)
+        trt_engine = trt_backend.TrtEngine(
+            model,
+            max_batch_size=1,
+            precision_mode=FLAGS.precision_mode,
+            engine_file_path=engine_file)
+    return trt_engine
+
+
+def eval():
+    trt_engine = load_trt_engine()
+    bboxes_list, bbox_nums_list, image_id_list = [], [], []
+    cpu_mems, gpu_mems = 0, 0
+    sample_nums = len(val_loader)
+    with tqdm(
+            total=sample_nums,
+            bar_format='Evaluation stage, Run batch:|{bar}| {n_fmt}/{total_fmt}',
+            ncols=80) as t:
+        for data in val_loader:
+            data_all = {k: np.array(v) for k, v in data.items()}
+            outs = trt_engine.infer([data_all['image']])
+            outs = np.array(outs).reshape(1, -1, 85)
+            postprocess = YOLOPostProcess(
+                score_threshold=0.001, nms_threshold=0.65, multi_label=True)
+            res = postprocess(np.array(outs), data_all['scale_factor'])
+            bboxes_list.append(res['bbox'])
+            bbox_nums_list.append(res['bbox_num'])
+            image_id_list.append(np.array(data_all['im_id']))
+            cpu_mem, gpu_mem = get_current_memory_mb()
+            cpu_mems += cpu_mem
+            gpu_mems += gpu_mem
+            t.update()
+    print('Avg cpu_mem:{} MB, avg gpu_mem: {} MB'.format(
+        cpu_mems / sample_nums, gpu_mems / sample_nums))
+
+    coco_metric(anno_file, bboxes_list, bbox_nums_list, image_id_list)
+
+
+def infer():
+    origin_img = cv2.imread(FLAGS.image_file)
+    input_shape = [640, 640]
+    input_image, scale_factor = preprocess(origin_img, input_shape)
+    input_image = np.expand_dims(input_image, axis=0)
+    scale_factor = np.array([[scale_factor, scale_factor]])
+    trt_engine = load_trt_engine()
+
+    repeat = 100
+    cpu_mems, gpu_mems = 0, 0
+    for _ in range(0, repeat):
+        outs = trt_engine.infer(input_image)
+        cpu_mem, gpu_mem = get_current_memory_mb()
+        cpu_mems += cpu_mem
+        gpu_mems += gpu_mem
+    print('Avg cpu_mem:{} MB, avg gpu_mem: {} MB'.format(cpu_mems / repeat,
+                                                         gpu_mems / repeat))
+    # Do postprocess
+    outs = np.array(outs).reshape(1, -1, 85)
+    postprocess = YOLOPostProcess(
+        score_threshold=0.1, nms_threshold=0.45, multi_label=False)
+    res = postprocess(np.array(outs), scale_factor)
+    # Draw rectangles and labels on the original image
+    dets = res['bbox']
+    if dets is not None:
+        final_boxes, final_scores, final_class = dets[:, 2:], dets[:,
+                                                                   1], dets[:,
+                                                                            0]
+        origin_img = draw_box(
+            origin_img,
+            final_boxes,
+            final_scores,
+            final_class,
+            conf=0.5,
+            class_names=CLASS_LABEL)
+    cv2.imwrite('output.jpg', origin_img)
+    print('The prediction results are saved in output.jpg.')
+
+
+def main():
+    if FLAGS.image_file:
+        infer()
+    else:
+        global val_loader
+        dataset = COCOValDataset(
+            dataset_dir=FLAGS.dataset_dir,
+            image_dir=FLAGS.val_image_dir,
+            anno_path=FLAGS.val_anno_path)
+        global anno_file
+        anno_file = dataset.ann_file
+        val_loader = paddle.io.DataLoader(
+            dataset, batch_size=FLAGS.batch_size, drop_last=True)
+        eval()
+
+
+if __name__ == '__main__':
+    paddle.enable_static()
+    parser = argsparser()
+    FLAGS = parser.parse_args()
+
+    paddle.set_device('cpu')
+
+    main()

--- a/tools/auto_compression/YOLOv6_quantization_act.ipynb
+++ b/tools/auto_compression/YOLOv6_quantization_act.ipynb
@@ -1,0 +1,325 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# YOLOv6 Quantization Compression Example\n",
+    "\n",
+    "This example uses [ACT](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/auto_compression) from [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim) for YOLOv6 quantization.\n",
+    "The quantized model can be deployed on TensorRT.\n",
+    "\n",
+    "- Benchmark\n",
+    "\n",
+    "| Model | Base mAP<sup>val<br>0.5:0.95  | Quant mAP<sup>val<br>0.5:0.95 | Latency<sup><small>FP32</small><sup><br><sup> | Latency<sup><small>FP16</small><sup><br><sup> | Latency<sup><small>INT8</small><sup><br><sup> | Model |\n",
+    "| :-------- |:-------- |:--------: | :--------: | :---------------------: | :----------------: | :----------------: |\n",
+    "| YOLOv6s |  42.4   | 41.3  |  9.06ms  |   2.90ms   |  **1.83ms**  | [ONNX](https://github.com/meituan/YOLOv6/releases/download/0.1.0/yolov6s.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov6s_quant_onnx.tar) |\n",
+    "| YOLOv6-Tiny  |  40.8   | 39.0 |  5.06ms  |   2.32ms   |  **1.68ms** | [ONNX](https://github.com/meituan/YOLOv6/releases/download/0.1.0/yolov6t.onnx) &#124; [Quant ONNX](https://bj.bcebos.com/v1/paddle-slim-models/act/yolov6_tiny_quant_onnx.tar) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Experiment\n",
+    "\n",
+    "(1) Environment Dependencies Installation:\n",
+    "  - paddlepaddle>=2.3.2\n",
+    "  - paddleslim>=2.3.4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Take Ubuntu and CUDA 11.2 as an example for GPU, and other environments can be installed directly according to Paddle's official website.\n",
+    "#  https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/install/pip/linux-pip.html \n",
+    "\n",
+    "!python -m pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html\n",
+    "\n",
+    "# CPU\n",
+    "#!pip install paddlepaddle==2.3.2\n",
+    "\n",
+    "!pip install paddleslim==2.3.4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(2) Model Preparation: the YOLOv6 ONNX model (currently only exclude NMS are supported)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# export yolov6s.onnx\n",
+    "!python ./deploy/ONNX/export_onnx.py \\\n",
+    "    --weights yolov6s.pt \\\n",
+    "    --img 640 \\\n",
+    "    --batch 1\n",
+    "\n",
+    "# Can also directly download the exported ONNX model\n",
+    "# !https://github.com/meituan/YOLOv6/releases/download/0.1.0/yolov6s.onnx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(3) Dataset Preparation (some unlabeled pictures of real scenes):\n",
+    "\n",
+    "The directory format is as follows:\n",
+    "```\n",
+    "image_dir\n",
+    "├── 000000000139.jpg\n",
+    "├── 000000000285.jpg\n",
+    "├── ...\n",
+    "```\n",
+    "\n",
+    "We use COCO's official `val` set as the image path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_dir' = './dataset/coco/val2017/'\n",
+    "model_dir = './yolov6s.onnx'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(4) Dependency Packages Import:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "os.environ['CUDA_VISIBLE_DEVICES'] = '0'\n",
+    "import paddle\n",
+    "from paddleslim.auto_compression import AutoCompression\n",
+    "\n",
+    "paddle.set_device('gpu')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(5) Definition of Data Preprocessing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _generate_scale(im, target_shape, keep_ratio=True):\n",
+    "    origin_shape = im.shape[:2]\n",
+    "    im_size_min = np.min(origin_shape)\n",
+    "    im_size_max = np.max(origin_shape)\n",
+    "    target_size_min = np.min(target_shape)\n",
+    "    target_size_max = np.max(target_shape)\n",
+    "    im_scale = float(target_size_min) / float(im_size_min)\n",
+    "    if np.round(im_scale * im_size_max) > target_size_max:\n",
+    "        im_scale = float(target_size_max) / float(im_size_max)\n",
+    "    im_scale_x = im_scale\n",
+    "    im_scale_y = im_scale\n",
+    "    return im_scale_y, im_scale_x\n",
+    "\n",
+    "def image_preprocess(img, target_shape=[640,640]):\n",
+    "    # Resize image\n",
+    "    im_scale_y, im_scale_x = _generate_scale(img, target_shape)\n",
+    "    img = cv2.resize(\n",
+    "        img,\n",
+    "        None,\n",
+    "        None,\n",
+    "        fx=im_scale_x,\n",
+    "        fy=im_scale_y,\n",
+    "        interpolation=cv2.INTER_LINEAR)\n",
+    "    # Pad\n",
+    "    im_h, im_w = img.shape[:2]\n",
+    "    h, w = target_shape[:]\n",
+    "    if h != im_h or w != im_w:\n",
+    "        canvas = np.ones((h, w, 3), dtype=np.float32)\n",
+    "        canvas *= np.array([114.0, 114.0, 114.0], dtype=np.float32)\n",
+    "        canvas[0:im_h, 0:im_w, :] = img.astype(np.float32)\n",
+    "        img = canvas\n",
+    "    img = np.transpose(img / 255, [2, 0, 1])\n",
+    "    return img.astype(np.float32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(6) Definition of Configuration for AutoCompression:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_config = {\n",
+    "    'Distillation': {\n",
+    "        'alpha': 1.0,\n",
+    "        'loss': 'soft_label'},\n",
+    "    'Quantization': {\n",
+    "        'onnx_format': True,\n",
+    "        'activation_quantize_type': 'moving_average_abs_max',\n",
+    "        'quantize_op_types': ['conv2d', 'depthwise_conv2d']},\n",
+    "    'TrainConfig': {\n",
+    "        'train_iter': 2000,\n",
+    "        'eval_iter': 1000,\n",
+    "        'learning_rate': 0.00003,\n",
+    "        'optimizer_builder': {'optimizer': {'type': 'SGD'}, 'weight_decay': 4e-05}}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(7) Auto Compression:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def reader_wrapper(reader, input_name='x2paddle_image_arrays'):\n",
+    "    def gen():\n",
+    "        for data in reader:\n",
+    "            yield {input_name: data[0]}\n",
+    "    return gen\n",
+    "\n",
+    "paddle.vision.image.set_image_backend('cv2')\n",
+    "train_dataset = paddle.vision.datasets.ImageFolder(image_dir, transform=image_preprocess)\n",
+    "train_loader = paddle.io.DataLoader(train_dataset, batch_size=1, shuffle=True, drop_last=True, num_workers=0)\n",
+    "\n",
+    "ac = AutoCompression(\n",
+    "    model_dir=model_dir,\n",
+    "    train_dataloader=reader_wrapper(train_loader),\n",
+    "    save_dir='output',\n",
+    "    config=run_config,\n",
+    "    eval_callback=None)\n",
+    "ac.compress()\n",
+    "# convert to ONNX\n",
+    "ac.export_onnx()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After executing the program, output files will be generated in the output folder as shown below:\n",
+    "```shell\n",
+    "├── model.pdiparams         # Paddle predicts model weights\n",
+    "├── model.pdmodel           # Paddle prediction model file\n",
+    "├── calibration_table.txt   # Paddle calibration table after quantification\n",
+    "├── ONNX\n",
+    "│   ├── quant_model.onnx      # ONNX model after quantization\n",
+    "│   ├── calibration.cache     # TensorRT can directly load the calibration table\n",
+    "```\n",
+    "\n",
+    "- Speed Test:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!trtexec --onnx=output/ONNX/quant_model.onnx --avgRuns=1000 --workspace=1024 --calib=output/ONNX/calibration.cache --int8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Python test:\n",
+    "\n",
+    "Load `quant_model.onnx` and `calibration.cache`, you can directly use the TensorRT test script to verify. The detailed code can refer to [TensorRT deployment](/TensorRT).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/PaddlePaddle/PaddleSlim.git\n",
+    "!cd example/auto_compression/pytorch_yolo_series/TensorRT\n",
+    "!python trt_eval.py --onnx_model_file=output/ONNX/quant_model.onnx \\\n",
+    "                   --calibration_file=output/ONNX/calibration.cache \\\n",
+    "                   --image_file=../images/000000570688.jpg \\\n",
+    "                   --precision_mode=int8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And you can also eval COCO mAP:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python trt_eval.py --onnx_model_file=output/ONNX/quant_model.onnx \\\n",
+    "                   --calibration_file=output/ONNX/calibration.cache \\\n",
+    "                   --precision_mode=int8 \\\n",
+    "                   --dataset_dir=dataset/coco/ \\\n",
+    "                   --val_image_dir=val2017 \\\n",
+    "                   --val_anno_path=annotations/instances_val2017.json"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tools/auto_compression/configs/yolov6_tiny_qat_dis.yaml
+++ b/tools/auto_compression/configs/yolov6_tiny_qat_dis.yaml
@@ -1,0 +1,32 @@
+Global:
+  model_dir: ./yolov6t.onnx
+  image_path: None   # If image_path is set, it will be trained directly based on unlabeled images, no need to set the COCO dataset path.
+  coco_dataset_dir: /paddle/dataset/coco/
+  coco_train_image_dir: train2017
+  coco_train_anno_path: annotations/instances_train2017.json
+  coco_val_image_dir: val2017
+  coco_val_anno_path: annotations/instances_val2017.json
+  arch: YOLOv6
+
+Distillation:
+  alpha: 1.0
+  loss: soft_label
+
+Quantization:
+  onnx_format: true
+  activation_quantize_type: 'moving_average_abs_max'
+  quantize_op_types:
+  - conv2d
+  - depthwise_conv2d
+
+TrainConfig:
+  train_iter: 8000
+  eval_iter: 1000
+  learning_rate:
+    type: CosineAnnealingDecay
+    learning_rate: 0.00003
+    T_max: 8000
+  optimizer_builder:
+    optimizer:
+      type: SGD
+    weight_decay: 0.00004

--- a/tools/auto_compression/configs/yolov6s_qat_dis.yaml
+++ b/tools/auto_compression/configs/yolov6s_qat_dis.yaml
@@ -1,0 +1,32 @@
+Global:
+  model_dir: ./yolov6s.onnx
+  image_path: None   # If image_path is set, it will be trained directly based on unlabeled images, no need to set the COCO dataset path.
+  coco_dataset_dir: /paddle/dataset/coco/
+  coco_train_image_dir: train2017
+  coco_train_anno_path: annotations/instances_train2017.json
+  coco_val_image_dir: val2017
+  coco_val_anno_path: annotations/instances_val2017.json
+  arch: YOLOv6
+
+Distillation:
+  alpha: 1.0
+  loss: soft_label
+
+Quantization:
+  onnx_format: true
+  activation_quantize_type: 'moving_average_abs_max'
+  quantize_op_types:
+  - conv2d
+  - depthwise_conv2d
+
+TrainConfig:
+  train_iter: 8000
+  eval_iter: 1000
+  learning_rate:
+    type: CosineAnnealingDecay
+    learning_rate: 0.00003
+    T_max: 8000
+  optimizer_builder:
+    optimizer:
+      type: SGD
+    weight_decay: 0.00004

--- a/tools/auto_compression/dataset.py
+++ b/tools/auto_compression/dataset.py
@@ -1,0 +1,151 @@
+import cv2
+import os
+import numpy as np
+import paddle
+
+
+class COCOValDataset(paddle.io.Dataset):
+    def __init__(self,
+                 dataset_dir=None,
+                 image_dir=None,
+                 anno_path=None,
+                 img_size=[640, 640],
+                 input_name='x2paddle_images'):
+        from pycocotools.coco import COCO
+        self.dataset_dir = dataset_dir
+        self.image_dir = image_dir
+        self.img_size = img_size
+        self.input_name = input_name
+        self.ann_file = os.path.join(dataset_dir, anno_path)
+        self.coco = COCO(self.ann_file)
+        ori_ids = list(sorted(self.coco.imgs.keys()))
+        # check gt bbox
+        clean_ids = []
+        for idx in ori_ids:
+            ins_anno_ids = self.coco.getAnnIds(imgIds=[idx], iscrowd=False)
+            instances = self.coco.loadAnns(ins_anno_ids)
+            num_bbox = 0
+            for inst in instances:
+                if inst.get('ignore', False):
+                    continue
+                if 'bbox' not in inst.keys():
+                    continue
+                elif not any(np.array(inst['bbox'])):
+                    continue
+                else:
+                    num_bbox += 1
+            if num_bbox > 0:
+                clean_ids.append(idx)
+        self.ids = clean_ids
+
+    def __getitem__(self, idx):
+        img_id = self.ids[idx]
+        img = self._get_img_data_from_img_id(img_id)
+        img, scale_factor = self.image_preprocess(img, self.img_size)
+        return {
+            'image': img,
+            'im_id': np.array([img_id]),
+            'scale_factor': scale_factor
+        }
+
+    def __len__(self):
+        return len(self.ids)
+
+    def _get_img_data_from_img_id(self, img_id):
+        img_info = self.coco.loadImgs(img_id)[0]
+        img_path = os.path.join(self.dataset_dir, self.image_dir,
+                                img_info['file_name'])
+        img = cv2.imread(img_path)
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        return img
+
+    def _generate_scale(self, im, target_shape, keep_ratio=True):
+        """
+            Args:
+                im (np.ndarray): image (np.ndarray)
+            Returns:
+                im_scale_x: the resize ratio of X
+                im_scale_y: the resize ratio of Y
+            """
+        origin_shape = im.shape[:2]
+        if keep_ratio:
+            im_size_min = np.min(origin_shape)
+            im_size_max = np.max(origin_shape)
+            target_size_min = np.min(target_shape)
+            target_size_max = np.max(target_shape)
+            im_scale = float(target_size_min) / float(im_size_min)
+            if np.round(im_scale * im_size_max) > target_size_max:
+                im_scale = float(target_size_max) / float(im_size_max)
+            im_scale_x = im_scale
+            im_scale_y = im_scale
+        else:
+            resize_h, resize_w = target_shape
+            im_scale_y = resize_h / float(origin_shape[0])
+            im_scale_x = resize_w / float(origin_shape[1])
+        return im_scale_y, im_scale_x
+
+    def image_preprocess(self, img, target_shape):
+        # Resize image
+        im_scale_y, im_scale_x = self._generate_scale(img, target_shape)
+        img = cv2.resize(
+            img,
+            None,
+            None,
+            fx=im_scale_x,
+            fy=im_scale_y,
+            interpolation=cv2.INTER_LINEAR)
+        # Pad
+        im_h, im_w = img.shape[:2]
+        h, w = target_shape[:]
+        if h != im_h or w != im_w:
+            canvas = np.ones((h, w, 3), dtype=np.float32)
+            canvas *= np.array([114.0, 114.0, 114.0], dtype=np.float32)
+            canvas[0:im_h, 0:im_w, :] = img.astype(np.float32)
+            img = canvas
+        img = np.transpose(img / 255, [2, 0, 1])
+        scale_factor = np.array([im_scale_y, im_scale_x])
+        return img.astype(np.float32), scale_factor
+
+
+class COCOTrainDataset(COCOValDataset):
+    def __getitem__(self, idx):
+        img_id = self.ids[idx]
+        img = self._get_img_data_from_img_id(img_id)
+        img, scale_factor = self.image_preprocess(img, self.img_size)
+        return {self.input_name: img}
+
+
+def _generate_scale(im, target_shape):
+    origin_shape = im.shape[:2]
+    im_size_min = np.min(origin_shape)
+    im_size_max = np.max(origin_shape)
+    target_size_min = np.min(target_shape)
+    target_size_max = np.max(target_shape)
+    im_scale = float(target_size_min) / float(im_size_min)
+    if np.round(im_scale * im_size_max) > target_size_max:
+        im_scale = float(target_size_max) / float(im_size_max)
+    im_scale_x = im_scale
+    im_scale_y = im_scale
+    return im_scale_y, im_scale_x
+
+
+def yolo_image_preprocess(img, target_shape=[640, 640]):
+    # Resize image
+    im_scale_y, im_scale_x = _generate_scale(img, target_shape)
+    img = cv2.resize(
+        img,
+        None,
+        None,
+        fx=im_scale_x,
+        fy=im_scale_y,
+        interpolation=cv2.INTER_LINEAR)
+    # Pad
+    im_h, im_w = img.shape[:2]
+    h, w = target_shape[:]
+    if h != im_h or w != im_w:
+        canvas = np.ones((h, w, 3), dtype=np.float32)
+        canvas *= np.array([114.0, 114.0, 114.0], dtype=np.float32)
+        canvas[0:im_h, 0:im_w, :] = img.astype(np.float32)
+        img = canvas
+    img = np.transpose(img / 255, [2, 0, 1])
+    return img.astype(np.float32)

--- a/tools/auto_compression/paddle_trt_infer.py
+++ b/tools/auto_compression/paddle_trt_infer.py
@@ -1,0 +1,326 @@
+import os
+import cv2
+import numpy as np
+import argparse
+import time
+
+from paddle.inference import Config
+from paddle.inference import create_predictor
+
+from post_process import YOLOPostProcess
+
+CLASS_LABEL = [
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train',
+    'truck', 'boat', 'traffic light', 'fire hydrant', 'stop sign',
+    'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+    'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag',
+    'tie', 'suitcase', 'frisbee', 'skis', 'snowboard', 'sports ball', 'kite',
+    'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+    'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon',
+    'bowl', 'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot',
+    'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch', 'potted plant',
+    'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote',
+    'keyboard', 'cell phone', 'microwave', 'oven', 'toaster', 'sink',
+    'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
+    'hair drier', 'toothbrush'
+]
+
+
+def generate_scale(im, target_shape, keep_ratio=True):
+    """
+        Args:
+            im (np.ndarray): image (np.ndarray)
+        Returns:
+            im_scale_x: the resize ratio of X
+            im_scale_y: the resize ratio of Y
+        """
+    origin_shape = im.shape[:2]
+    if keep_ratio:
+        im_size_min = np.min(origin_shape)
+        im_size_max = np.max(origin_shape)
+        target_size_min = np.min(target_shape)
+        target_size_max = np.max(target_shape)
+        im_scale = float(target_size_min) / float(im_size_min)
+        if np.round(im_scale * im_size_max) > target_size_max:
+            im_scale = float(target_size_max) / float(im_size_max)
+        im_scale_x = im_scale
+        im_scale_y = im_scale
+    else:
+        resize_h, resize_w = target_shape
+        im_scale_y = resize_h / float(origin_shape[0])
+        im_scale_x = resize_w / float(origin_shape[1])
+    return im_scale_y, im_scale_x
+
+
+def image_preprocess(img_path, target_shape):
+    img = cv2.imread(img_path)
+    # Resize
+    im_scale_y, im_scale_x = generate_scale(img, target_shape)
+    img = cv2.resize(
+        img,
+        None,
+        None,
+        fx=im_scale_x,
+        fy=im_scale_y,
+        interpolation=cv2.INTER_LINEAR)
+    # Pad
+    im_h, im_w = img.shape[:2]
+    h, w = target_shape[:]
+    if h != im_h or w != im_w:
+        canvas = np.ones((h, w, 3), dtype=np.float32)
+        canvas *= np.array([114.0, 114.0, 114.0], dtype=np.float32)
+        canvas[0:im_h, 0:im_w, :] = img.astype(np.float32)
+        img = canvas
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    img = np.transpose(img, [2, 0, 1]) / 255
+    img = np.expand_dims(img, 0)
+    scale_factor = np.array([[im_scale_y, im_scale_x]])
+    return img.astype(np.float32), scale_factor
+
+
+def get_color_map_list(num_classes):
+    color_map = num_classes * [0, 0, 0]
+    for i in range(0, num_classes):
+        j = 0
+        lab = i
+        while lab:
+            color_map[i * 3] |= (((lab >> 0) & 1) << (7 - j))
+            color_map[i * 3 + 1] |= (((lab >> 1) & 1) << (7 - j))
+            color_map[i * 3 + 2] |= (((lab >> 2) & 1) << (7 - j))
+            j += 1
+            lab >>= 3
+    color_map = [color_map[i:i + 3] for i in range(0, len(color_map), 3)]
+    return color_map
+
+
+def draw_box(image_file, results, class_label, threshold=0.5):
+    srcimg = cv2.imread(image_file, 1)
+    for i in range(len(results)):
+        color_list = get_color_map_list(len(class_label))
+        clsid2color = {}
+        classid, conf = int(results[i, 0]), results[i, 1]
+        if conf < threshold:
+            continue
+        xmin, ymin, xmax, ymax = int(results[i, 2]), int(results[i, 3]), int(
+            results[i, 4]), int(results[i, 5])
+
+        if classid not in clsid2color:
+            clsid2color[classid] = color_list[classid]
+        color = tuple(clsid2color[classid])
+
+        cv2.rectangle(srcimg, (xmin, ymin), (xmax, ymax), color, thickness=2)
+        print(class_label[classid] + ': ' + str(round(conf, 3)))
+        cv2.putText(
+            srcimg,
+            class_label[classid] + ':' + str(round(conf, 3)), (xmin, ymin - 10),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.8, (0, 255, 0),
+            thickness=2)
+    return srcimg
+
+
+def load_predictor(model_dir,
+                   run_mode='paddle',
+                   batch_size=1,
+                   device='CPU',
+                   min_subgraph_size=3,
+                   use_dynamic_shape=False,
+                   trt_min_shape=1,
+                   trt_max_shape=1280,
+                   trt_opt_shape=640,
+                   trt_calib_mode=False,
+                   cpu_threads=1,
+                   enable_mkldnn=False,
+                   enable_mkldnn_bfloat16=False,
+                   delete_shuffle_pass=False):
+    """set AnalysisConfig, generate AnalysisPredictor
+    Args:
+        model_dir (str): root path of __model__ and __params__
+        device (str): Choose the device you want to run, it can be: CPU/GPU/XPU, default is CPU
+        run_mode (str): mode of running(paddle/trt_fp32/trt_fp16/trt_int8)
+        use_dynamic_shape (bool): use dynamic shape or not
+        trt_min_shape (int): min shape for dynamic shape in trt
+        trt_max_shape (int): max shape for dynamic shape in trt
+        trt_opt_shape (int): opt shape for dynamic shape in trt
+        trt_calib_mode (bool): If the model is produced by TRT offline quantitative
+            calibration, trt_calib_mode need to set True
+        delete_shuffle_pass (bool): whether to remove shuffle_channel_detect_pass in TensorRT.
+                                    Used by action model.
+    Returns:
+        predictor (PaddlePredictor): AnalysisPredictor
+    Raises:
+        ValueError: predict by TensorRT need device == 'GPU'.
+    """
+    rerun_flag = False
+    if device != 'GPU' and run_mode != 'paddle':
+        raise ValueError(
+            "Predict by TensorRT mode: {}, expect device=='GPU', but device == {}"
+            .format(run_mode, device))
+    config = Config(
+        os.path.join(model_dir, 'model.pdmodel'),
+        os.path.join(model_dir, 'model.pdiparams'))
+    if device == 'GPU':
+        # initial GPU memory(M), device ID
+        config.enable_use_gpu(200, 0)
+        # optimize graph and fuse op
+        config.switch_ir_optim(True)
+    elif device == 'XPU':
+        config.enable_lite_engine()
+        config.enable_xpu(10 * 1024 * 1024)
+    else:
+        config.disable_gpu()
+        config.set_cpu_math_library_num_threads(cpu_threads)
+        if enable_mkldnn:
+            try:
+                # cache 10 different shapes for mkldnn to avoid memory leak
+                config.set_mkldnn_cache_capacity(10)
+                config.enable_mkldnn()
+                if enable_mkldnn_bfloat16:
+                    config.enable_mkldnn_bfloat16()
+            except Exception as e:
+                print(
+                    "The current environment does not support `mkldnn`, so disable mkldnn."
+                )
+                pass
+
+    precision_map = {
+        'trt_int8': Config.Precision.Int8,
+        'trt_fp32': Config.Precision.Float32,
+        'trt_fp16': Config.Precision.Half
+    }
+    if run_mode in precision_map.keys():
+        config.enable_tensorrt_engine(
+            workspace_size=(1 << 25) * batch_size,
+            max_batch_size=batch_size,
+            min_subgraph_size=min_subgraph_size,
+            precision_mode=precision_map[run_mode],
+            use_static=False,
+            use_calib_mode=trt_calib_mode)
+
+        if use_dynamic_shape:
+            dynamic_shape_file = os.path.join(args.model_path,
+                                              'dynamic_shape.txt')
+            if os.path.exists(dynamic_shape_file):
+                config.enable_tuned_tensorrt_dynamic_shape(dynamic_shape_file,
+                                                           True)
+                print('trt set dynamic shape done!')
+            else:
+                config.collect_shape_range_info(dynamic_shape_file)
+                print('Start collect dynamic shape...')
+                rerun_flag = True
+
+    # disable print log when predict
+    config.disable_glog_info()
+    # enable shared memory
+    config.enable_memory_optim()
+    # disable feed, fetch OP, needed by zero_copy_run
+    config.switch_use_feed_fetch_ops(False)
+    if delete_shuffle_pass:
+        config.delete_pass("shuffle_channel_detect_pass")
+    predictor = create_predictor(config)
+    return predictor, rerun_flag
+
+
+def predict_image(predictor,
+                  image_file,
+                  image_shape=[640, 640],
+                  warmup=1,
+                  repeats=1,
+                  threshold=0.5,
+                  arch='YOLOv5'):
+    img, scale_factor = image_preprocess(image_file, image_shape)
+    inputs = {}
+    if arch == 'YOLOv6':
+        inputs['x2paddle_image_arrays'] = img
+    else:
+        inputs['x2paddle_images'] = img
+    input_names = predictor.get_input_names()
+    for i in range(len(input_names)):
+        input_tensor = predictor.get_input_handle(input_names[i])
+        input_tensor.copy_from_cpu(inputs[input_names[i]])
+
+    for i in range(warmup):
+        predictor.run()
+
+    np_boxes = None
+    predict_time = 0.
+    time_min = float("inf")
+    time_max = float('-inf')
+    for i in range(repeats):
+        start_time = time.time()
+        predictor.run()
+        output_names = predictor.get_output_names()
+        boxes_tensor = predictor.get_output_handle(output_names[0])
+        np_boxes = boxes_tensor.copy_to_cpu()
+        end_time = time.time()
+        timed = end_time - start_time
+        time_min = min(time_min, timed)
+        time_max = max(time_max, timed)
+        predict_time += timed
+
+    time_avg = predict_time / repeats
+    print('Inference time(ms): min={}, max={}, avg={}'.format(
+        round(time_min * 1000, 2),
+        round(time_max * 1000, 1), round(time_avg * 1000, 1)))
+    postprocess = YOLOPostProcess(
+        score_threshold=0.001, nms_threshold=0.65, multi_label=True)
+    res = postprocess(np_boxes, scale_factor)
+    res_img = draw_box(
+        image_file, res['bbox'], CLASS_LABEL, threshold=threshold)
+    cv2.imwrite('result.jpg', res_img)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--image_file', type=str, default=None, help="image path")
+    parser.add_argument(
+        '--model_path', type=str, help="inference model filepath")
+    parser.add_argument(
+        '--benchmark',
+        type=bool,
+        default=False,
+        help="Whether run benchmark or not.")
+    parser.add_argument(
+        '--use_dynamic_shape',
+        type=bool,
+        default=True,
+        help="Whether use dynamic shape or not.")
+    parser.add_argument(
+        '--run_mode',
+        type=str,
+        default='paddle',
+        help="mode of running(paddle/trt_fp32/trt_fp16/trt_int8)")
+    parser.add_argument(
+        '--device',
+        type=str,
+        default='GPU',
+        help="Choose the device you want to run, it can be: CPU/GPU/XPU, default is GPU"
+    )
+    parser.add_argument(
+        '--arch', type=str, default='YOLOv5', help="architectures name.")
+    parser.add_argument('--img_shape', type=int, default=640, help="input_size")
+    args = parser.parse_args()
+
+    warmup, repeats = 1, 1
+    if args.benchmark:
+        warmup, repeats = 50, 100
+
+    predictor, rerun_flag = load_predictor(
+        args.model_path,
+        run_mode=args.run_mode,
+        device=args.device,
+        use_dynamic_shape=args.use_dynamic_shape)
+    predict_image(
+        predictor,
+        args.image_file,
+        image_shape=[args.img_shape, args.img_shape],
+        warmup=warmup,
+        repeats=repeats,
+        arch=args.arch)
+
+    if rerun_flag:
+        print(
+            "***** Collect dynamic shape done, Please rerun the program to get correct results. *****"
+        )

--- a/tools/auto_compression/post_process.py
+++ b/tools/auto_compression/post_process.py
@@ -1,0 +1,217 @@
+import numpy as np
+import cv2
+import json
+import sys
+
+
+def box_area(boxes):
+    """
+    Args:
+        boxes(np.ndarray): [N, 4]
+    return: [N]
+    """
+    return (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+
+
+def box_iou(box1, box2):
+    """
+    Args:
+        box1(np.ndarray): [N, 4]
+        box2(np.ndarray): [M, 4]
+    return: [N, M]
+    """
+    area1 = box_area(box1)
+    area2 = box_area(box2)
+    lt = np.maximum(box1[:, np.newaxis, :2], box2[:, :2])
+    rb = np.minimum(box1[:, np.newaxis, 2:], box2[:, 2:])
+    wh = rb - lt
+    wh = np.maximum(0, wh)
+    inter = wh[:, :, 0] * wh[:, :, 1]
+    iou = inter / (area1[:, np.newaxis] + area2 - inter)
+    return iou
+
+
+def nms(boxes, scores, iou_threshold):
+    """
+    Non Max Suppression numpy implementation.
+    args:
+        boxes(np.ndarray): [N, 4]
+        scores(np.ndarray): [N, 1]
+        iou_threshold(float): Threshold of IoU.
+    """
+    idxs = scores.argsort()
+    keep = []
+    while idxs.size > 0:
+        max_score_index = idxs[-1]
+        max_score_box = boxes[max_score_index][None, :]
+        keep.append(max_score_index)
+        if idxs.size == 1:
+            break
+        idxs = idxs[:-1]
+        other_boxes = boxes[idxs]
+        ious = box_iou(max_score_box, other_boxes)
+        idxs = idxs[ious[0] <= iou_threshold]
+
+    keep = np.array(keep)
+    return keep
+
+
+class YOLOPostProcess(object):
+    """
+    Post process of YOLO-series network.
+    args:
+        score_threshold(float): Threshold to filter out bounding boxes with low
+                confidence score. If not provided, consider all boxes.
+        nms_threshold(float): The threshold to be used in NMS.
+        multi_label(bool): Whether keep multi label in boxes.
+        keep_top_k(int): Number of total bboxes to be kept per image after NMS
+                step. -1 means keeping all bboxes after NMS step.
+    """
+
+    def __init__(self,
+                 score_threshold=0.25,
+                 nms_threshold=0.5,
+                 multi_label=False,
+                 keep_top_k=300):
+        self.score_threshold = score_threshold
+        self.nms_threshold = nms_threshold
+        self.multi_label = multi_label
+        self.keep_top_k = keep_top_k
+
+    def _xywh2xyxy(self, x):
+        # Convert from [x, y, w, h] to [x1, y1, x2, y2]
+        y = np.copy(x)
+        y[:, 0] = x[:, 0] - x[:, 2] / 2  # top left x
+        y[:, 1] = x[:, 1] - x[:, 3] / 2  # top left y
+        y[:, 2] = x[:, 0] + x[:, 2] / 2  # bottom right x
+        y[:, 3] = x[:, 1] + x[:, 3] / 2  # bottom right y
+        return y
+
+    def _non_max_suppression(self, prediction):
+        max_wh = 4096  # (pixels) minimum and maximum box width and height
+        nms_top_k = 30000
+
+        cand_boxes = prediction[..., 4] > self.score_threshold  # candidates
+        output = [np.zeros((0, 6))] * prediction.shape[0]
+
+        for batch_id, boxes in enumerate(prediction):
+            # Apply constraints
+            boxes = boxes[cand_boxes[batch_id]]
+            if not boxes.shape[0]:
+                continue
+            # Compute conf (conf = obj_conf * cls_conf)
+            boxes[:, 5:] *= boxes[:, 4:5]
+
+            # Box (center x, center y, width, height) to (x1, y1, x2, y2)
+            convert_box = self._xywh2xyxy(boxes[:, :4])
+
+            # Detections matrix nx6 (xyxy, conf, cls)
+            if self.multi_label:
+                i, j = (boxes[:, 5:] > self.score_threshold).nonzero()
+                boxes = np.concatenate(
+                    (convert_box[i], boxes[i, j + 5, None],
+                     j[:, None].astype(np.float32)),
+                    axis=1)
+            else:
+                conf = np.max(boxes[:, 5:], axis=1)
+                j = np.argmax(boxes[:, 5:], axis=1)
+                re = np.array(conf.reshape(-1) > self.score_threshold)
+                conf = conf.reshape(-1, 1)
+                j = j.reshape(-1, 1)
+                boxes = np.concatenate((convert_box, conf, j), axis=1)[re]
+
+            num_box = boxes.shape[0]
+            if not num_box:
+                continue
+            elif num_box > nms_top_k:
+                boxes = boxes[boxes[:, 4].argsort()[::-1][:nms_top_k]]
+
+            # Batched NMS
+            c = boxes[:, 5:6] * max_wh
+            clean_boxes, scores = boxes[:, :4] + c, boxes[:, 4]
+            keep = nms(clean_boxes, scores, self.nms_threshold)
+            # limit detection box num
+            if keep.shape[0] > self.keep_top_k:
+                keep = keep[:self.keep_top_k]
+            output[batch_id] = boxes[keep]
+        return output
+
+    def __call__(self, outs, scale_factor):
+        preds = self._non_max_suppression(outs)
+        bboxs, box_nums = [], []
+        for i, pred in enumerate(preds):
+            if len(pred.shape) > 2:
+                pred = np.squeeze(pred)
+            if len(pred.shape) == 1:
+                pred = pred[np.newaxis, :]
+            pred_bboxes = pred[:, :4]
+            scale = np.tile(scale_factor[i][::-1], (2))
+            pred_bboxes /= scale
+            bbox = np.concatenate(
+                [
+                    pred[:, -1][:, np.newaxis], pred[:, -2][:, np.newaxis],
+                    pred_bboxes
+                ],
+                axis=-1)
+            bboxs.append(bbox)
+            box_num = bbox.shape[0]
+            box_nums.append(box_num)
+        bboxs = np.concatenate(bboxs, axis=0)
+        box_nums = np.array(box_nums)
+        return {'bbox': bboxs, 'bbox_num': box_nums}
+
+
+def coco_metric(anno_file, bboxes_list, bbox_nums_list, image_id_list):
+    try:
+        from pycocotools.coco import COCO
+        from pycocotools.cocoeval import COCOeval
+    except:
+        print(
+            "[ERROR] Not found pycocotools, please install by `pip install pycocotools`"
+        )
+        sys.exit(1)
+
+    coco_gt = COCO(anno_file)
+    cats = coco_gt.loadCats(coco_gt.getCatIds())
+    clsid2catid = {i: cat['id'] for i, cat in enumerate(cats)}
+    results = []
+    for bboxes, bbox_nums, image_id in zip(bboxes_list, bbox_nums_list,
+                                           image_id_list):
+        results += _get_det_res(bboxes, bbox_nums, image_id, clsid2catid)
+
+    output = "bbox.json"
+    with open(output, 'w') as f:
+        json.dump(results, f)
+
+    coco_dt = coco_gt.loadRes(output)
+    coco_eval = COCOeval(coco_gt, coco_dt, 'bbox')
+    coco_eval.evaluate()
+    coco_eval.accumulate()
+    coco_eval.summarize()
+    return coco_eval.stats
+
+
+def _get_det_res(bboxes, bbox_nums, image_id, label_to_cat_id_map):
+    det_res = []
+    k = 0
+    for i in range(len(bbox_nums)):
+        cur_image_id = int(image_id[i][0])
+        det_nums = bbox_nums[i]
+        for j in range(det_nums):
+            dt = bboxes[k]
+            k = k + 1
+            num_id, score, xmin, ymin, xmax, ymax = dt.tolist()
+            if int(num_id) < 0:
+                continue
+            category_id = label_to_cat_id_map[int(num_id)]
+            w = xmax - xmin
+            h = ymax - ymin
+            bbox = [xmin, ymin, w, h]
+            dt_res = {
+                'image_id': cur_image_id,
+                'category_id': category_id,
+                'bbox': bbox,
+                'score': score
+            }
+            det_res.append(dt_res)
+    return det_res

--- a/tools/auto_compression/run.py
+++ b/tools/auto_compression/run.py
@@ -1,0 +1,132 @@
+import os
+import sys
+import numpy as np
+import argparse
+from tqdm import tqdm
+import paddle
+from paddleslim.common import load_config
+from paddleslim.auto_compression import AutoCompression
+from dataset import COCOValDataset, COCOTrainDataset, yolo_image_preprocess
+from post_process import YOLOPostProcess, coco_metric
+
+
+def argsparser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--config_path',
+        type=str,
+        default=None,
+        help="path of compression strategy config.",
+        required=True)
+    parser.add_argument(
+        '--save_dir',
+        type=str,
+        default='output',
+        help="directory to save compressed model.")
+    parser.add_argument(
+        '--devices',
+        type=str,
+        default='gpu',
+        help="which device used to compress.")
+
+    return parser
+
+
+def reader_wrapper(reader, input_name='x2paddle_images'):
+    def gen():
+        for data in reader:
+            yield {input_name: data[0]}
+
+    return gen
+
+
+def eval_function(exe, compiled_test_program, test_feed_names, test_fetch_list):
+    bboxes_list, bbox_nums_list, image_id_list = [], [], []
+    with tqdm(
+            total=len(val_loader),
+            bar_format='Evaluation stage, Run batch:|{bar}| {n_fmt}/{total_fmt}',
+            ncols=80) as t:
+        for data in val_loader:
+            data_all = {k: np.array(v) for k, v in data.items()}
+            outs = exe.run(compiled_test_program,
+                           feed={test_feed_names[0]: data_all['image']},
+                           fetch_list=test_fetch_list,
+                           return_numpy=False)
+            res = {}
+            postprocess = YOLOPostProcess(
+                score_threshold=0.001, nms_threshold=0.65, multi_label=True)
+            res = postprocess(np.array(outs[0]), data_all['scale_factor'])
+            bboxes_list.append(res['bbox'])
+            bbox_nums_list.append(res['bbox_num'])
+            image_id_list.append(np.array(data_all['im_id']))
+            t.update()
+    map_res = coco_metric(anno_file, bboxes_list, bbox_nums_list, image_id_list)
+    return map_res[0]
+
+
+def main():
+    global global_config
+    all_config = load_config(FLAGS.config_path)
+    assert "Global" in all_config, f"Key 'Global' not found in config file. \n{all_config}"
+    global_config = all_config["Global"]
+    input_name = 'x2paddle_image_arrays' if global_config[
+        'arch'] == 'YOLOv6' else 'x2paddle_images'
+
+    if global_config['image_path'] != 'None':
+        assert os.path.exists(global_config['image_path'])
+        paddle.vision.image.set_image_backend('cv2')
+        train_dataset = paddle.vision.datasets.ImageFolder(
+            global_config['image_path'], transform=yolo_image_preprocess)
+        train_loader = paddle.io.DataLoader(
+            train_dataset,
+            batch_size=1,
+            shuffle=True,
+            drop_last=True,
+            num_workers=0)
+        train_loader = reader_wrapper(train_loader, input_name=input_name)
+        eval_func = None
+    else:
+        dataset = COCOTrainDataset(
+            dataset_dir=global_config['coco_dataset_dir'],
+            image_dir=global_config['coco_train_image_dir'],
+            anno_path=global_config['coco_train_anno_path'],
+            input_name=input_name)
+        train_loader = paddle.io.DataLoader(
+            dataset, batch_size=1, shuffle=True, drop_last=True, num_workers=0)
+        if paddle.distributed.get_rank() == 0:
+            eval_func = eval_function
+            global val_loader
+            dataset = COCOValDataset(
+                dataset_dir=global_config['coco_dataset_dir'],
+                image_dir=global_config['coco_val_image_dir'],
+                anno_path=global_config['coco_val_anno_path'])
+            global anno_file
+            anno_file = dataset.ann_file
+            val_loader = paddle.io.DataLoader(
+                dataset,
+                batch_size=1,
+                shuffle=False,
+                drop_last=False,
+                num_workers=0)
+        else:
+            eval_func = None
+
+    ac = AutoCompression(
+        model_dir=global_config["model_dir"],
+        train_dataloader=train_loader,
+        save_dir=FLAGS.save_dir,
+        config=all_config,
+        eval_callback=eval_func)
+    ac.compress()
+    ac.export_onnx()
+
+
+if __name__ == '__main__':
+    paddle.enable_static()
+    parser = argsparser()
+    FLAGS = parser.parse_args()
+
+    assert FLAGS.devices in ['cpu', 'gpu', 'xpu', 'npu']
+    paddle.set_device(FLAGS.devices)
+
+    main()


### PR DESCRIPTION
We used [PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim) ACT(Auto Compression Toolkit) to quantize and compress YOLOv6, and the results on T4  with TensorRT are as follows:

| Model | Base mAP<sup>val<br>0.5:0.95  | Quant mAP<sup>val<br>0.5:0.95 | Latency<sup><small>FP32</small><sup><br><sup> | Latency<sup><small>FP16</small><sup><br><sup> | Latency<sup><small>INT8</small><sup><br><sup> | 
| :-------- |:-------- |:--------: | :--------: | :---------------------: | :----------------: | 
| YOLOv6s |  42.4   | 41.3  |  9.06ms  |   2.90ms   |  **1.83ms**  | 
| YOLOv6-Tiny  |  40.8   | 39.0 |  5.06ms  |   2.32ms   |  **1.68ms** | 