### PR TITLE
updated redme for doing  images testing

### DIFF
--- a/deploy/TensorRT/README.md
+++ b/deploy/TensorRT/README.md
@@ -70,3 +70,12 @@ Then run the demo:
 ```shell
 ./yolov6 ../you.engine -i image_path
 ```
+# Testing on image 
+You can do testing on images using .trt weights, just give path of image directory & its annotation path
+
+```
+python3 deploy/TensorRT/eval_yolo_trt.py -v -m model.trt \
+--imgs-dir /workdir/datasets/coco/images/val2017 \
+--annotations /workdir/datasets/coco/annotations/instances_val2017.json \
+--conf-thres 0.25 --iou-thres 0.45
+```

--- a/deploy/TensorRT/README.md
+++ b/deploy/TensorRT/README.md
@@ -77,5 +77,5 @@ You can do testing on images using .trt weights, just give path of image directo
 python3 deploy/TensorRT/eval_yolo_trt.py -v -m model.trt \
 --imgs-dir /workdir/datasets/coco/images/val2017 \
 --annotations /workdir/datasets/coco/annotations/instances_val2017.json \
---conf-thres 0.25 --iou-thres 0.45
+--conf-thres 0.40 --iou-thres 0.45
 ```


### PR DESCRIPTION
fixed : https://github.com/meituan/YOLOv6/issues/453
using .trt weight  we can do testing on images
@mtjhl @shensheng272 
```
python3 deploy/TensorRT/eval_yolo_trt.py -v -m model.trt \
--imgs-dir /workdir/datasets/coco/images/val2017 \
--annotations /workdir/datasets/coco/annotations/instances_val2017.json \
--conf-thres 0.25 --iou-thres 0.45```