### PR TITLE
[Bug]fix the bug cause siou to be nan

### DIFF
--- a/yolov6/utils/figure_iou.py
+++ b/yolov6/utils/figure_iou.py
@@ -74,8 +74,8 @@ class IOUloss:
                 iou = iou - (rho2 / c2 + v * alpha)
         elif self.iou_type == 'siou':
             # SIoU Loss https://arxiv.org/pdf/2205.12740.pdf
-            s_cw = (b2_x1 + b2_x2 - b1_x1 - b1_x2) * 0.5
-            s_ch = (b2_y1 + b2_y2 - b1_y1 - b1_y2) * 0.5
+            s_cw = (b2_x1 + b2_x2 - b1_x1 - b1_x2) * 0.5 + self.eps
+            s_ch = (b2_y1 + b2_y2 - b1_y1 - b1_y2) * 0.5 + self.eps
             sigma = torch.pow(s_cw ** 2 + s_ch ** 2, 0.5)
             sin_alpha_1 = torch.abs(s_cw) / sigma
             sin_alpha_2 = torch.abs(s_ch) / sigma


### PR DESCRIPTION
When the training reaches the later stage, the center points of the prediction box and the gt box may coincide, causing sigma==0, resulting in loss_ iou==nan.