### PR TITLE
Add YouTube Tutorial to Third-party resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ python tools/infer.py --weights yolov6s.pt --source img.jpg / imgdir / video.mp4
 
  * Tutorial: [How to train YOLOv6 on a custom dataset](https://blog.roboflow.com/how-to-train-yolov6-on-a-custom-dataset/) <a href="https://colab.research.google.com/drive/1YnbqOinBZV-c9I7fk_UL6acgnnmkXDMM"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
 
+ * YouTube Tutorial: [How to train YOLOv6 on a custom dataset](https://youtu.be/fFCWrMFH2UY)
+
  * Demo of YOLOv6 inference on Google Colab [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mahdilamb/YOLOv6/blob/main/inference.ipynb)
 
  * Blog post: [YOLOv6 Object Detection – Paper Explanation and Inference](https://learnopencv.com/yolov6-object-detection/)


### PR DESCRIPTION
Hi 👋! Yesterday we released the YOLOv6 YouTube tutorial. Given the fact that until now, there were no videos in third-party resources, I thought it could be a nice addition. 

We covered:
- Inference on the COCO dataset
- Training on custom dataset
- Evaluation on custom dataset
- Inference on custom dataset