### PR TITLE
fix ONNX export commands and reference to pretrained models

### DIFF
--- a/docs/Train_custom_data.md
+++ b/docs/Train_custom_data.md
@@ -78,7 +78,7 @@ names: ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', '
 We use a config file to specify the network structure and training setting, including  optimizer and data augmentation hyperparameters.
 
 If you create a new config file, please put it under the `configs` directory.
-Or just use the provided config file in `$YOLOV6_HOME/configs/*_finetune.py`.
+Or just use the provided config file in `$YOLOV6_HOME/configs/*_finetune.py`. Download the pretrained models you want from according to your configuration [here](https://github.com/meituan/YOLOv6#benchmark).
 
 ```python
 ## YOLOv6s Model config file

--- a/docs/Train_custom_data.md
+++ b/docs/Train_custom_data.md
@@ -142,5 +142,5 @@ python tools/infer.py --weights output_dir/name/weights/best_ckpt.pt --source im
 Export as [ONNX](https://github.com/meituan/YOLOv6/tree/main/deploy/ONNX) Format
 
 ```shell
-python deploy/ONNX/export_onnx.py --weights output_dir/name/weights/best_ckpt.pt --simplify --device 0
+python deploy/ONNX/export_onnx.py --weights output_dir/name/weights/best_ckpt.pt --simplify --device 0 --dynamic-batch --end2end --ort
 ```


### PR DESCRIPTION
This PR does the followings below and closes #672.

1. Update notebook in `deploy/ONNX/YOLOv6-Dynamic-Batch-onnxruntime.ipynb` with new ONNX export command and changes for accuractly drawing bounding boxes. 
2. Add reference to pretrained model when pretraining different models on custom data.
3. Update export to ONNX command in `docs/Train_custom_data.md`