### PR TITLE
698 fix update numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 torch>=1.8.0
 torchvision>=0.9.0
-numpy>=1.18.5
+numpy>=1.24.0
 opencv-python>=4.1.2
 PyYAML>=5.3.1
 scipy>=1.4.1

--- a/yolov6/data/datasets.py
+++ b/yolov6/data/datasets.py
@@ -72,7 +72,7 @@ class TrainValDataset(Dataset):
             self.batch_indices = np.floor(
                 np.arange(len(shapes)) / self.batch_size
             ).astype(
-                np.int
+                np.int_
             )  # batch indices of each image
             self.sort_files_shapes()
         t2 = time.time()
@@ -446,7 +446,7 @@ class TrainValDataset(Dataset):
                 shapes[i] = [1, 1 / mini]
         self.batch_shapes = (
             np.ceil(np.array(shapes) * self.img_size / self.stride + self.pad).astype(
-                np.int
+                np.int_
             )
             * self.stride
         )


### PR DESCRIPTION
This PR resolves #667 and closes #698. If someone were to try and use YOLOv6 for the first time and cloned the latest (or 6.3), upon starting training, they would run into an error immediately. This is due to requirements.txt allowing for numpy 1.24.0 (or greater) to be installed. As changes were made to the Numpy API, this breaks datasets.py. This PR updates datasets.py and requirements.txt.