### PR TITLE
Fixed tutorial notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ English | [简体中文](README_cn.md)
 
  <div>
     </a>
-    <a href="[https://colab.research.google.com/github/meituan/YOLOv6/blob/main/turtorial.ipynb](https://colab.research.google.com/gist/HouSanDuo123/bdad4ad6706209d4e9275d2186d54289/tutorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
+    <a href="https://colab.research.google.com/github/meituan/YOLOv6/blob/main/turtorial.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
      <a href="https://www.kaggle.com/code/housanduo/yolov6"><img src="https://kaggle.com/static/images/open-in-kaggle.svg" alt="Open In Kaggle"></a>
   </div>
  <br>

--- a/tools/quantization/tensorrt/post_training/README.md
+++ b/tools/quantization/tensorrt/post_training/README.md
@@ -30,7 +30,7 @@ or want to create a new one.
 
 ## INT8 Calibration
 
-See [ImagenetCalibrator.py](ImagenetCalibrator.py) for a reference implementation
+See [Calibrator.py](Calibrator.py) for a reference implementation
 of TensorRT's [IInt8EntropyCalibrator2](https://docs.nvidia.com/deeplearning/sdk/tensorrt-api/python_api/infer/Int8/EntropyCalibrator2.html).
 
 This class can be tweaked to work for other kinds of models, inputs, etc.
@@ -43,7 +43,7 @@ However, to calibrate using different data or a different model, you can do so w
 * This requires that you've mounted a dataset, such as Imagenet, to use for calibration.
     * Add something like `-v /imagenet:/imagenet` to your Docker command in Step (1)
       to mount a dataset found locally at `/imagenet`.
-* You can specify your own `preprocess_func` by defining it inside of `ImageCalibrator.py`
+* You can specify your own `preprocess_func` by defining it inside of `Calibrator.py`
 
 ```bash
 # Path to dataset to use for calibration.

--- a/turtorial.ipynb
+++ b/turtorial.ipynb
@@ -1223,7 +1223,7 @@
         "!python tools/infer.py --weights yolov6s.pt --source data/images/image1.jpg\n",
         "# show image\n",
         "from google.colab.patches import cv2_imshow, cv2\n",
-        "img = cv2.imread('runs/inference/image1.jpg')\n",
+        "img = cv2.imread('runs/inference/exp/image1.jpg')\n",
         "cv2_imshow(img)"
       ],
       "metadata": {
@@ -1462,6 +1462,7 @@
       "cell_type": "code",
       "source": [
         "# Before running, you need to make sure you're in the YOLOv6 root directory.\n",
+        "%cd ../../YOLOv6\n",
         "# Train YOLOv6s on COCO for 30 epochs\n",
         "!python tools/train.py --img 640 --batch 32 --epochs 30 --conf configs/yolov6s.py --data data/coco.yaml"
       ],
@@ -1500,6 +1501,35 @@
       "metadata": {
         "id": "az4pa71UuObL"
       }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "coco128 = \"\"\"# Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]\n",
+        "path: ../coco128  # dataset root dir\n",
+        "train: ../coco128/images/train2017  # train images 128 images\n",
+        "val: ../coco128/images/train2017  # val images 128 images\n",
+        "test:  # test images (optional)\n",
+        "\n",
+        "# Classes\n",
+        "nc: 80  # number of classes\n",
+        "names: ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',\n",
+        "        'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',\n",
+        "        'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',\n",
+        "        'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',\n",
+        "        'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',\n",
+        "        'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',\n",
+        "        'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',\n",
+        "        'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',\n",
+        "        'hair drier', 'toothbrush']  # class names\n",
+        "\"\"\"\n",
+        "\n",
+        "with open('data/coco128.yaml', 'w') as f:\n",
+        "  f.write(coco128)"
+      ]
     },
     {
       "cell_type": "code",


### PR DESCRIPTION
Hi.
1. Fixed `tutorial.ipynb` notebook:
- fixed path to `image1.jpg` image, previously there was an `AttributeError` due to the wrong path:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/36787333/217219272-23e386ce-4a79-4aff-aa9c-1263cd5d207a.png">

- changed directory to `%cd ../../YOLOv6` to successfully train on coco dataset, previously there was an error:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/36787333/217219526-93beb55b-6333-4ec2-968d-c529c2cdf75a.png">

- created `coco128.yaml` config file as stated as a comment in the notebook.
2. Fixed link to colab badge, now works as expected. Previously only the image opened.
3. Fixed path to `Calibrator.py` inside `tools/quantization/tensorrt/post_training/README.md`
