### PR TITLE
Fix image color mode in hubconf script

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,4 +1,5 @@
 import os
+import cv2
 import math
 import pathlib
 import torch
@@ -70,7 +71,13 @@ def check_img_size(img_size, s=32, floor=0):
 
 def process_image(path, img_size, stride):
     '''Preprocess image before inference.'''
-    img_src = np.asarray(Image.open(path).convert('RGB'))
+    try:
+            img_src = cv2.imread(path)
+            assert img_src is not None, f"opencv cannot read image correctly or {path} not exists"
+    except:
+            img_src = cv2.cvtColor(np.asarray(Image.open(path)), cv2.COLOR_RGB2BGR)
+            assert img_src is not None, f"Image Not Found {path}, workdir: {os.getcwd()}"
+
     image = letterbox(img_src, img_size, stride=stride)[0]
     image = image.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
     image = torch.from_numpy(np.ascontiguousarray(image))


### PR DESCRIPTION
Currently, in the `hubconf.py` inference script the input image to the model is in `BGR` mode. In this PR, the methodology is the same as in the [load_image](https://github.com/meituan/YOLOv6/blob/main/yolov6/data/datasets.py#L180), i.e. read the image in `BGR` mode and convert it to `RGB` before getting parsed into the model.