### PR TITLE
New eval function of yolov6

### DIFF
--- a/tags
+++ b/tags
@@ -1,0 +1,3940 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+APP_BASE_NAME	deploy/NCNN/Android/gradlew.bat	/^set APP_BASE_NAME=%~n0$/;"	v
+APP_HOME	deploy/NCNN/Android/gradlew.bat	/^for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi$/;"	v
+APP_HOME	deploy/NCNN/Android/gradlew.bat	/^set APP_HOME=%DIRNAME%$/;"	v
+ATSSAssigner	yolov6/assigners/atss_assigner.py	/^class ATSSAssigner(nn.Module):$/;"	c
+BBOX_CONF_THRESH	deploy/TensorRT/yolov6.cpp	26;"	d	file:
+BLACK	deploy/ONNX/OpenCV/yolo.py	/^BLACK  = (0,0,0)$/;"	v
+BLACK	deploy/ONNX/OpenCV/yolo_video.py	/^BLACK  = (0,0,0)$/;"	v
+BLACK	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^Scalar BLACK = Scalar(0,0,0);$/;"	v
+BLACK	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^Scalar BLACK = Scalar(0,0,0);$/;"	v
+BLUE	deploy/ONNX/OpenCV/yolo.py	/^BLUE   = (255,178,50)$/;"	v
+BLUE	deploy/ONNX/OpenCV/yolo_video.py	/^BLUE   = (255,178,50)$/;"	v
+BLUE	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^Scalar BLUE = Scalar(255, 178, 50);$/;"	v
+BLUE	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^Scalar BLUE = Scalar(255, 178, 50);$/;"	v
+BboxLoss	yolov6/models/losses/loss.py	/^class BboxLoss(nn.Module):$/;"	c
+BboxLoss	yolov6/models/losses/loss_distill.py	/^class BboxLoss(nn.Module):$/;"	c
+BboxLoss	yolov6/models/losses/loss_distill_ns.py	/^class BboxLoss(nn.Module):$/;"	c
+BboxLoss	yolov6/models/losses/loss_fuseab.py	/^class BboxLoss(nn.Module):$/;"	c
+BepC3	yolov6/layers/common.py	/^class BepC3(nn.Module):$/;"	c
+BiFusion	yolov6/layers/common.py	/^class BiFusion(nn.Module):$/;"	c
+BottleRep	yolov6/layers/common.py	/^class BottleRep(nn.Module):$/;"	c
+BottleRep3	yolov6/layers/common.py	/^class BottleRep3(nn.Module):$/;"	c
+CHECK	deploy/TensorRT/yolov6.cpp	13;"	d	file:
+CLASSPATH	deploy/NCNN/Android/gradlew.bat	/^set CLASSPATH=%APP_HOME%\\gradle\\wrapper\\gradle-wrapper.jar$/;"	v
+CLASS_COLORS	deploy/NCNN/infer-ncnn-model.py	/^CLASS_COLORS = [(220, 20, 60), (119, 11, 32), (0, 0, 142), (0, 0, 230),$/;"	v
+CLASS_NAMES	deploy/NCNN/infer-ncnn-model.py	/^CLASS_NAMES = ('person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',$/;"	v
+CLASS_NAMES	hubconf.py	/^CLASS_NAMES = load_yaml(str(PATH_YOLOv6\/"data\/coco.yaml"))['names']$/;"	v
+CONFIDENCE_THRESHOLD	deploy/ONNX/OpenCV/yolo.py	/^CONFIDENCE_THRESHOLD = 0.45		# obj confidence$/;"	v
+CONFIDENCE_THRESHOLD	deploy/ONNX/OpenCV/yolo_video.py	/^CONFIDENCE_THRESHOLD = 0.2$/;"	v
+CONFIDENCE_THRESHOLD	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const float CONFIDENCE_THRESHOLD = 0.45;$/;"	v
+CONFIDENCE_THRESHOLD	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const float CONFIDENCE_THRESHOLD = 0.45;$/;"	v
+CONF_THRES	deploy/NCNN/infer-ncnn-model.py	/^CONF_THRES = 0.45$/;"	v
+CSPBepBackbone	yolov6/models/efficientrep.py	/^class CSPBepBackbone(nn.Module):$/;"	c
+CSPBepBackbone_P6	yolov6/models/efficientrep.py	/^class CSPBepBackbone_P6(nn.Module):$/;"	c
+CSPBlock	yolov6/layers/common.py	/^class CSPBlock(nn.Module):$/;"	c
+CSPRepBiFPANNeck	yolov6/models/reppan.py	/^class CSPRepBiFPANNeck(nn.Module):$/;"	c
+CSPRepBiFPANNeck_P6	yolov6/models/reppan.py	/^class CSPRepBiFPANNeck_P6(nn.Module):$/;"	c
+CSPRepPANNeck	yolov6/models/reppan.py	/^class CSPRepPANNeck(nn.Module):$/;"	c
+CSPRepPANNeck_P6	yolov6/models/reppan.py	/^class CSPRepPANNeck_P6(nn.Module):$/;"	c
+CSPSPPF	yolov6/layers/common.py	/^class CSPSPPF(nn.Module):$/;"	c
+CSPSPPFModule	yolov6/layers/common.py	/^class CSPSPPFModule(nn.Module):$/;"	c
+CalcFPS	yolov6/core/inferer.py	/^class CalcFPS:$/;"	c
+Calibrator	deploy/TensorRT/calibrator.py	/^class Calibrator(trt.IInt8MinMaxCalibrator):$/;"	c
+ComputeLoss	yolov6/models/losses/loss.py	/^class ComputeLoss:$/;"	c
+ComputeLoss	yolov6/models/losses/loss_distill.py	/^class ComputeLoss:$/;"	c
+ComputeLoss	yolov6/models/losses/loss_distill_ns.py	/^class ComputeLoss:$/;"	c
+ComputeLoss	yolov6/models/losses/loss_fuseab.py	/^class ComputeLoss:$/;"	c
+Config	yolov6/utils/config.py	/^class Config(object):$/;"	c
+ConfigDict	yolov6/utils/config.py	/^class ConfigDict(Dict):$/;"	c
+ConfusionMatrix	yolov6/utils/metrics.py	/^class ConfusionMatrix:$/;"	c
+ConvBN	yolov6/layers/common.py	/^class ConvBN(nn.Module):$/;"	c
+ConvBNHS	yolov6/layers/common.py	/^class ConvBNHS(nn.Module):$/;"	c
+ConvBNReLU	yolov6/layers/common.py	/^class ConvBNReLU(nn.Module):$/;"	c
+ConvBNSiLU	yolov6/layers/common.py	/^class ConvBNSiLU(nn.Module):$/;"	c
+ConvModule	yolov6/layers/common.py	/^class ConvModule(nn.Module):$/;"	c
+DEFAULT_JVM_OPTS	deploy/NCNN/Android/gradlew.bat	/^set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"$/;"	v
+DEVICE	deploy/TensorRT/yolov6.cpp	24;"	d	file:
+DEVICE	hubconf.py	/^DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')$/;"	v
+DIRNAME	deploy/NCNN/Android/gradlew.bat	/^if "%DIRNAME%" == "" set DIRNAME=.$/;"	v
+DIRNAME	deploy/NCNN/Android/gradlew.bat	/^set DIRNAME=%~dp0$/;"	v
+DPBlock	yolov6/layers/common.py	/^class DPBlock(nn.Module):$/;"	c
+DarknetBlock	yolov6/layers/common.py	/^class DarknetBlock(nn.Module):$/;"	c
+DataLoader	deploy/TensorRT/calibrator.py	/^class DataLoader:$/;"	c
+Detect	yolov6/models/effidehead.py	/^class Detect(nn.Module):$/;"	c
+Detect	yolov6/models/heads/effidehead_distill_ns.py	/^class Detect(nn.Module):$/;"	c
+Detect	yolov6/models/heads/effidehead_fuseab.py	/^class Detect(nn.Module):$/;"	c
+Detect	yolov6/models/heads/effidehead_lite.py	/^class Detect(nn.Module):$/;"	c
+DetectBackend	yolov6/layers/common.py	/^class DetectBackend(nn.Module):$/;"	c
+Detector	hubconf.py	/^class Detector(DetectBackend):$/;"	c
+EXPLICIT_BATCH	tools/quantization/ppq/write_qparams_onnx2trt.py	/^EXPLICIT_BATCH = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)$/;"	v
+EfficientRep	yolov6/models/efficientrep.py	/^class EfficientRep(nn.Module):$/;"	c
+EfficientRep6	yolov6/models/efficientrep.py	/^class EfficientRep6(nn.Module):$/;"	c
+End2End	yolov6/models/end2end.py	/^class End2End(nn.Module):$/;"	c
+Evaler	yolov6/core/evaler.py	/^class Evaler:$/;"	c
+EvalerWrapper	tools/partial_quantization/eval.py	/^class EvalerWrapper(object):$/;"	c
+FONT_FACE	deploy/ONNX/OpenCV/yolo.py	/^FONT_FACE = cv2.FONT_HERSHEY_SIMPLEX$/;"	v
+FONT_FACE	deploy/ONNX/OpenCV/yolo_video.py	/^FONT_FACE = cv2.FONT_HERSHEY_SIMPLEX$/;"	v
+FONT_FACE	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const int FONT_FACE = FONT_HERSHEY_SIMPLEX;$/;"	v
+FONT_FACE	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const int FONT_FACE = FONT_HERSHEY_SIMPLEX;$/;"	v
+FONT_SCALE	deploy/ONNX/OpenCV/yolo.py	/^FONT_SCALE = 0.7$/;"	v
+FONT_SCALE	deploy/ONNX/OpenCV/yolo_video.py	/^FONT_SCALE = 0.7$/;"	v
+FONT_SCALE	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const float FONT_SCALE = 0.7;$/;"	v
+FONT_SCALE	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const float FONT_SCALE = 0.7;$/;"	v
+GiB	tools/quantization/ppq/write_qparams_onnx2trt.py	/^def GiB(val):$/;"	f
+IMG_FORMATS	deploy/TensorRT/calibrator.py	/^IMG_FORMATS = [".bmp", ".jpg", ".jpeg", ".png", ".tif", ".tiff", ".dng", ".webp", ".mpo"]$/;"	v
+IMG_FORMATS	deploy/TensorRT/eval_yolo_trt.py	/^IMG_FORMATS = ["bmp", "jpg", "jpeg", "png", "tif", "tiff", "dng", "webp", "mpo"]$/;"	v
+IMG_FORMATS	yolov6/data/datasets.py	/^IMG_FORMATS = ["bmp", "jpg", "jpeg", "png", "tif", "tiff", "dng", "webp", "mpo"]$/;"	v
+IMG_FORMATS	yolov6/data/vis_dataset.py	/^IMG_FORMATS = ["bmp", "jpg", "jpeg", "png", "tif", "tiff", "dng", "webp", "mpo"]$/;"	v
+INPUT_BLOB_NAME	deploy/TensorRT/yolov6.cpp	/^const char* INPUT_BLOB_NAME = "image_arrays";$/;"	v
+INPUT_H	deploy/TensorRT/yolov6.cpp	/^static const int INPUT_H = 640;$/;"	v	file:
+INPUT_HEIGHT	deploy/ONNX/OpenCV/yolo.py	/^INPUT_HEIGHT = 640$/;"	v
+INPUT_HEIGHT	deploy/ONNX/OpenCV/yolo_video.py	/^INPUT_HEIGHT = 640$/;"	v
+INPUT_HEIGHT	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const float INPUT_HEIGHT = 640.0;$/;"	v
+INPUT_HEIGHT	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const float INPUT_HEIGHT = 640.0;$/;"	v
+INPUT_W	deploy/TensorRT/yolov6.cpp	/^static const int INPUT_W = 640;$/;"	v	file:
+INPUT_WIDTH	deploy/ONNX/OpenCV/yolo.py	/^INPUT_WIDTH = 640$/;"	v
+INPUT_WIDTH	deploy/ONNX/OpenCV/yolo_video.py	/^INPUT_WIDTH = 640$/;"	v
+INPUT_WIDTH	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const float INPUT_WIDTH = 640.0;$/;"	v
+INPUT_WIDTH	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const float INPUT_WIDTH = 640.0;$/;"	v
+IOU_THRES	deploy/NCNN/infer-ncnn-model.py	/^IOU_THRES = 0.65$/;"	v
+IOUloss	yolov6/utils/figure_iou.py	/^class IOUloss:$/;"	c
+ImageCalibrator	tools/quantization/tensorrt/post_training/Calibrator.py	/^class ImageCalibrator(trt.IInt8EntropyCalibrator2):$/;"	c
+Inferer	yolov6/core/inferer.py	/^class Inferer:$/;"	c
+JAVA_EXE	deploy/NCNN/Android/gradlew.bat	/^set JAVA_EXE=%JAVA_HOME%\/bin\/java.exe$/;"	v
+JAVA_EXE	deploy/NCNN/Android/gradlew.bat	/^set JAVA_EXE=java.exe$/;"	v
+JAVA_HOME	deploy/NCNN/Android/gradlew.bat	/^set JAVA_HOME=%JAVA_HOME:"=%$/;"	v
+JNI_OnLoad	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)$/;"	f
+JNI_OnUnload	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)$/;"	f
+Java_com_tencent_yolov6ncnn_Yolov6Ncnn_closeCamera	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^JNIEXPORT jboolean JNICALL Java_com_tencent_yolov6ncnn_Yolov6Ncnn_closeCamera(JNIEnv* env, jobject thiz)$/;"	f
+Java_com_tencent_yolov6ncnn_Yolov6Ncnn_loadModel	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^JNIEXPORT jboolean JNICALL Java_com_tencent_yolov6ncnn_Yolov6Ncnn_loadModel(JNIEnv* env, jobject thiz, jobject assetManager, jint modelid, jint cpugpu)$/;"	f
+Java_com_tencent_yolov6ncnn_Yolov6Ncnn_openCamera	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^JNIEXPORT jboolean JNICALL Java_com_tencent_yolov6ncnn_Yolov6Ncnn_openCamera(JNIEnv* env, jobject thiz, jint facing)$/;"	f
+Java_com_tencent_yolov6ncnn_Yolov6Ncnn_setOutputWindow	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^JNIEXPORT jboolean JNICALL Java_com_tencent_yolov6ncnn_Yolov6Ncnn_setOutputWindow(JNIEnv* env, jobject thiz, jobject surface)$/;"	f
+LOGGER	yolov6/utils/events.py	/^LOGGER = set_logging(__name__)$/;"	v
+LOG_ERROR	deploy/TensorRT/logging.h	/^inline LogStreamConsumer LOG_ERROR(const Logger& logger)$/;"	f	namespace:__anon1
+LOG_FATAL	deploy/TensorRT/logging.h	/^inline LogStreamConsumer LOG_FATAL(const Logger& logger)$/;"	f	namespace:__anon1
+LOG_INFO	deploy/TensorRT/logging.h	/^inline LogStreamConsumer LOG_INFO(const Logger& logger)$/;"	f	namespace:__anon1
+LOG_VERBOSE	deploy/TensorRT/logging.h	/^inline LogStreamConsumer LOG_VERBOSE(const Logger& logger)$/;"	f	namespace:__anon1
+LOG_WARN	deploy/TensorRT/logging.h	/^inline LogStreamConsumer LOG_WARN(const Logger& logger)$/;"	f	namespace:__anon1
+LinearAddBlock	yolov6/layers/common.py	/^class LinearAddBlock(nn.Module):$/;"	c
+Lite_EffiBackbone	yolov6/models/efficientrep.py	/^class Lite_EffiBackbone(nn.Module):$/;"	c
+Lite_EffiBlockS1	yolov6/layers/common.py	/^class Lite_EffiBlockS1(nn.Module):$/;"	c
+Lite_EffiBlockS2	yolov6/layers/common.py	/^class Lite_EffiBlockS2(nn.Module):$/;"	c
+Lite_EffiNeck	yolov6/models/reppan.py	/^class Lite_EffiNeck(nn.Module):$/;"	c
+LoadData	yolov6/data/datasets.py	/^class LoadData:$/;"	c
+LogStreamConsumer	deploy/TensorRT/logging.h	/^    LogStreamConsumer(LogStreamConsumer&& other)$/;"	f	class:LogStreamConsumer
+LogStreamConsumer	deploy/TensorRT/logging.h	/^    LogStreamConsumer(Severity reportableSeverity, Severity severity)$/;"	f	class:LogStreamConsumer
+LogStreamConsumer	deploy/TensorRT/logging.h	/^class LogStreamConsumer : protected LogStreamConsumerBase, public std::ostream$/;"	c
+LogStreamConsumerBase	deploy/TensorRT/logging.h	/^    LogStreamConsumerBase(std::ostream& stream, const std::string& prefix, bool shouldLog)$/;"	f	class:LogStreamConsumerBase
+LogStreamConsumerBase	deploy/TensorRT/logging.h	/^class LogStreamConsumerBase$/;"	c
+LogStreamConsumerBuffer	deploy/TensorRT/logging.h	/^    LogStreamConsumerBuffer(LogStreamConsumerBuffer&& other)$/;"	f	class:LogStreamConsumerBuffer
+LogStreamConsumerBuffer	deploy/TensorRT/logging.h	/^    LogStreamConsumerBuffer(std::ostream& stream, const std::string& prefix, bool shouldLog)$/;"	f	class:LogStreamConsumerBuffer
+LogStreamConsumerBuffer	deploy/TensorRT/logging.h	/^class LogStreamConsumerBuffer : public std::stringbuf$/;"	c
+Logger	deploy/TensorRT/logging.h	/^    Logger(Severity severity = Severity::kWARNING)$/;"	f	class:Logger
+Logger	deploy/TensorRT/logging.h	/^class Logger : public nvinfer1::ILogger$/;"	c
+MASK_COLORS	deploy/NCNN/infer-ncnn-model.py	/^MASK_COLORS = np.array([(255, 56, 56), (255, 157, 151), (255, 112, 31),$/;"	v
+MAX_BATCH_SIZE	deploy/TensorRT/onnx_to_trt.py	/^MAX_BATCH_SIZE = 1$/;"	v
+MBLABlock	yolov6/layers/common.py	/^class MBLABlock(nn.Module):$/;"	c
+MainActivity	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^public class MainActivity extends Activity implements SurfaceHolder.Callback$/;"	c
+Model	yolov6/models/yolo.py	/^class Model(nn.Module):$/;"	c
+Model	yolov6/models/yolo_lite.py	/^class Model(nn.Module):$/;"	c
+ModelEMA	yolov6/utils/ema.py	/^class ModelEMA:$/;"	c
+MyNdkCamera	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^class MyNdkCamera : public NdkCameraWindow$/;"	c	file:
+MyTQC	tools/quantization/ppq/ProgramEntrance.py	/^MyTQC = TQC($/;"	v
+NCOLS	yolov6/utils/events.py	/^NCOLS = min(100, shutil.get_terminal_size().columns)$/;"	v
+NDKCAMERAWINDOW_ID	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static const int NDKCAMERAWINDOW_ID = 233;$/;"	v	file:
+NDKCAMERA_H	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	16;"	d
+NMS_THRESH	deploy/TensorRT/yolov6.cpp	25;"	d	file:
+NMS_THRESHOLD	deploy/ONNX/OpenCV/yolo.py	/^NMS_THRESHOLD = 0.45$/;"	v
+NMS_THRESHOLD	deploy/ONNX/OpenCV/yolo_video.py	/^NMS_THRESHOLD = 0.45$/;"	v
+NMS_THRESHOLD	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const float NMS_THRESHOLD = 0.45;$/;"	v
+NMS_THRESHOLD	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const float NMS_THRESHOLD = 0.45;$/;"	v
+NdkCamera	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^NdkCamera::NdkCamera()$/;"	f	class:NdkCamera
+NdkCamera	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^class NdkCamera$/;"	c
+NdkCameraWindow	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^NdkCameraWindow::NdkCameraWindow() : NdkCamera()$/;"	f	class:NdkCameraWindow
+NdkCameraWindow	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^class NdkCameraWindow : public NdkCamera$/;"	c
+ONNX_ORT	yolov6/models/end2end.py	/^class ONNX_ORT(nn.Module):$/;"	c
+ONNX_TRT7	yolov6/models/end2end.py	/^class ONNX_TRT7(nn.Module):$/;"	c
+ONNX_TRT8	yolov6/models/end2end.py	/^class ONNX_TRT8(nn.Module):$/;"	c
+ORIENTATION	yolov6/data/datasets.py	/^        ORIENTATION = k$/;"	v
+ORT_NMS	yolov6/models/end2end.py	/^class ORT_NMS(torch.autograd.Function):$/;"	c
+OUTPUT_BLOB_NAME	deploy/TensorRT/yolov6.cpp	/^const char* OUTPUT_BLOB_NAME = "outputs";$/;"	v
+Object	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^struct Object$/;"	s
+Object	deploy/TensorRT/yolov6.cpp	/^struct Object$/;"	s	file:
+PATH_YOLOv6	hubconf.py	/^PATH_YOLOv6 = pathlib.Path(__file__).parent$/;"	v
+Processor	deploy/TensorRT/Processor.py	/^class Processor():$/;"	c
+Processor	deploy/TensorRT/tensorrt_processor.py	/^class Processor():$/;"	c
+QARepVGGBlock	yolov6/layers/common.py	/^class QARepVGGBlock(RepVGGBlock):$/;"	c
+QARepVGGBlockV2	yolov6/layers/common.py	/^class QARepVGGBlockV2(RepVGGBlock):$/;"	c
+RED	deploy/ONNX/OpenCV/yolo.py	/^RED = (0,0,255)$/;"	v
+RED	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^Scalar RED = Scalar(0,0,255);$/;"	v
+RED	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^Scalar RED = Scalar(0,0,255);$/;"	v
+REQUEST_CAMERA	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public static final int REQUEST_CAMERA = 100;$/;"	f	class:MainActivity
+ROOT	deploy/NCNN/export_torchscript.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	deploy/NCNN/infer-ncnn-model.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	deploy/ONNX/eval_trt.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	deploy/ONNX/export_onnx.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	deploy/OpenVINO/export_openvino.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	deploy/TensorRT/eval_yolo_trt.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	tools/eval.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	tools/infer.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	tools/partial_quantization/partial_quant.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	tools/partial_quantization/sensitivity_analyse.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	tools/qat/qat_export.py	/^ROOT = os.getcwd()$/;"	v
+ROOT	tools/train.py	/^ROOT = os.getcwd()$/;"	v
+RealVGGBlock	yolov6/layers/common.py	/^class RealVGGBlock(nn.Module):$/;"	c
+RepBiFPANNeck	yolov6/models/reppan.py	/^class RepBiFPANNeck(nn.Module):$/;"	c
+RepBiFPANNeck6	yolov6/models/reppan.py	/^class RepBiFPANNeck6(nn.Module):$/;"	c
+RepBlock	yolov6/layers/common.py	/^class RepBlock(nn.Module):$/;"	c
+RepPANNeck	yolov6/models/reppan.py	/^class RepPANNeck(nn.Module):$/;"	c
+RepPANNeck6	yolov6/models/reppan.py	/^class RepPANNeck6(nn.Module):$/;"	c
+RepVGGBlock	yolov6/layers/common.py	/^class RepVGGBlock(nn.Module):$/;"	c
+RepVGGOptimizer	yolov6/utils/RepOptimizer.py	/^class RepVGGOptimizer(SGD):$/;"	c
+SCORE_THRESHOLD	deploy/ONNX/OpenCV/yolo.py	/^SCORE_THRESHOLD = 0.5			# cls score$/;"	v
+SCORE_THRESHOLD	deploy/ONNX/OpenCV/yolo_video.py	/^SCORE_THRESHOLD = 0.5$/;"	v
+SCORE_THRESHOLD	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const float SCORE_THRESHOLD = 0.5;$/;"	v
+SCORE_THRESHOLD	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const float SCORE_THRESHOLD = 0.5;$/;"	v
+SEBlock	yolov6/layers/common.py	/^class SEBlock(nn.Module):$/;"	c
+SPPF	yolov6/layers/common.py	/^class SPPF(nn.Module):$/;"	c
+SPPFModule	yolov6/layers/common.py	/^class SPPFModule(nn.Module):$/;"	c
+ScaleLayer	yolov6/layers/common.py	/^class ScaleLayer(torch.nn.Module):$/;"	c
+SiLU	yolov6/layers/common.py	/^class SiLU(nn.Module):$/;"	c
+SimCSPSPPF	yolov6/layers/common.py	/^class SimCSPSPPF(nn.Module):$/;"	c
+SimSPPF	yolov6/layers/common.py	/^class SimSPPF(nn.Module):$/;"	c
+TENSORRT_LOGGING_H	deploy/TensorRT/logging.h	18;"	d
+THICKNESS	deploy/ONNX/OpenCV/yolo.py	/^THICKNESS = 1$/;"	v
+THICKNESS	deploy/ONNX/OpenCV/yolo_video.py	/^THICKNESS = 1$/;"	v
+THICKNESS	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^const int THICKNESS = 1;$/;"	v
+THICKNESS	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^const int THICKNESS = 1;$/;"	v
+TRT7_NMS	yolov6/models/end2end.py	/^class TRT7_NMS(torch.autograd.Function):$/;"	c
+TRT8_NMS	yolov6/models/end2end.py	/^class TRT8_NMS(torch.autograd.Function):$/;"	c
+TRT_LOGGER	tools/quantization/ppq/write_qparams_onnx2trt.py	/^TRT_LOGGER = trt.Logger()$/;"	v
+TRT_LOGGER	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^TRT_LOGGER = trt.Logger()$/;"	v
+TaskAlignedAssigner	yolov6/assigners/tal_assigner.py	/^class TaskAlignedAssigner(nn.Module):$/;"	c
+TestAtom	deploy/TensorRT/logging.h	/^        TestAtom(bool started, const std::string& name, const std::string& cmdline)$/;"	f	class:Logger::TestAtom
+TestAtom	deploy/TensorRT/logging.h	/^    class TestAtom$/;"	c	class:Logger
+TestResult	deploy/TensorRT/logging.h	/^    enum class TestResult$/;"	c	class:Logger
+TrainValDataLoader	yolov6/data/data_load.py	/^class TrainValDataLoader(dataloader.DataLoader):$/;"	c
+TrainValDataset	yolov6/data/datasets.py	/^class TrainValDataset(Dataset):$/;"	c
+Trainer	yolov6/core/engine.py	/^class Trainer:$/;"	c
+Transpose	yolov6/layers/common.py	/^class Transpose(nn.Module):$/;"	c
+VID_FORMATS	yolov6/data/datasets.py	/^VID_FORMATS = ["mp4", "mov", "avi", "mkv"]$/;"	v
+VOC_NAMES	yolov6/data/voc2yolo.py	/^VOC_NAMES = ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog',$/;"	v
+VarifocalLoss	yolov6/models/losses/loss.py	/^class VarifocalLoss(nn.Module):$/;"	c
+VarifocalLoss	yolov6/models/losses/loss_distill.py	/^class VarifocalLoss(nn.Module):$/;"	c
+VarifocalLoss	yolov6/models/losses/loss_distill_ns.py	/^class VarifocalLoss(nn.Module):$/;"	c
+VarifocalLoss	yolov6/models/losses/loss_fuseab.py	/^class VarifocalLoss(nn.Module):$/;"	c
+YELLOW	deploy/ONNX/OpenCV/yolo.py	/^YELLOW = (0,255,255)$/;"	v
+YELLOW	deploy/ONNX/OpenCV/yolo_video.py	/^YELLOW = (0,255,255)$/;"	v
+YELLOW	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^Scalar YELLOW = Scalar(0, 255, 255);$/;"	v
+YELLOW	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^Scalar YELLOW = Scalar(0, 255, 255);$/;"	v
+YOLO_H	deploy/NCNN/Android/app/src/main/jni/yolo.h	16;"	d
+Yolo	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^Yolo::Yolo()$/;"	f	class:Yolo
+Yolo	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^class Yolo$/;"	c
+Yolov6Ncnn	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/Yolov6Ncnn.java	/^public class Yolov6Ncnn$/;"	c
+_	tools/quantization/ppq/ProgramEntrance.py	/^_ = PFL.Quantizer(platform=TargetPlatform.GRAPHCORE_FP8, graph=graph)    # 取得 GRAPHCORE_FP8 所对应的量化器$/;"	v
+_	tools/quantization/ppq/ProgramEntrance.py	/^_ = PFL.Quantizer(platform=TargetPlatform.TRT_FP8, graph=graph)          # 取得 TRT_FP8 所对应的量化器$/;"	v
+_RepeatSampler	yolov6/data/data_load.py	/^class _RepeatSampler:$/;"	c
+__call__	yolov6/models/losses/loss.py	/^    def __call__($/;"	m	class:ComputeLoss	file:
+__call__	yolov6/models/losses/loss_distill.py	/^    def __call__($/;"	m	class:ComputeLoss	file:
+__call__	yolov6/models/losses/loss_distill_ns.py	/^    def __call__($/;"	m	class:ComputeLoss	file:
+__call__	yolov6/models/losses/loss_fuseab.py	/^    def __call__($/;"	m	class:ComputeLoss	file:
+__call__	yolov6/utils/figure_iou.py	/^    def __call__(self, box1, box2):$/;"	m	class:IOUloss	file:
+__del__	yolov6/data/datasets.py	/^    def __del__(self):$/;"	m	class:TrainValDataset	file:
+__getattr__	yolov6/utils/config.py	/^    def __getattr__(self, name):$/;"	m	class:Config	file:
+__getattr__	yolov6/utils/config.py	/^    def __getattr__(self, name):$/;"	m	class:ConfigDict	file:
+__getitem__	yolov6/data/datasets.py	/^    def __getitem__(self, index):$/;"	m	class:TrainValDataset	file:
+__init__	deploy/ONNX/OpenCV/yolox.py	/^    def __init__(self, model, classesFile, p6=False, confThreshold=0.5, nmsThreshold=0.5, objThreshold=0.5):$/;"	m	class:yolox
+__init__	deploy/TensorRT/Processor.py	/^    def __init__(self, model, num_classes=80, num_layers=3, anchors=1, device=torch.device('cuda:0'), return_int=False, scale_exact=False, force_no_pad=False, is_end2end=False):$/;"	m	class:Processor
+__init__	deploy/TensorRT/calibrator.py	/^    def __init__(self, batch_size, batch_num, calib_img_dir, input_w, input_h):$/;"	m	class:DataLoader
+__init__	deploy/TensorRT/calibrator.py	/^    def __init__(self, stream, cache_file=""):$/;"	m	class:Calibrator
+__init__	deploy/TensorRT/tensorrt_processor.py	/^    def __init__(self, model, num_classes=80, num_layers=3, anchors=1, device=torch.device('cuda:0'), is_end2end=False):$/;"	m	class:Processor
+__init__	hubconf.py	/^    def __init__(self,$/;"	m	class:Detector
+__init__	tools/partial_quantization/eval.py	/^    def __init__(self, eval_cfg):$/;"	m	class:EvalerWrapper
+__init__	tools/quantization/tensorrt/post_training/Calibrator.py	/^    def __init__(self, calibration_files=[], batch_size=32, input_shape=(3, 224, 224),$/;"	m	class:ImageCalibrator
+__init__	yolov6/assigners/atss_assigner.py	/^    def __init__(self,$/;"	m	class:ATSSAssigner
+__init__	yolov6/assigners/tal_assigner.py	/^    def __init__(self,$/;"	m	class:TaskAlignedAssigner
+__init__	yolov6/core/engine.py	/^    def __init__(self, args, cfg, device):$/;"	m	class:Trainer
+__init__	yolov6/core/evaler.py	/^    def __init__(self,$/;"	m	class:Evaler
+__init__	yolov6/core/inferer.py	/^    def __init__(self, nsamples: int = 50):$/;"	m	class:CalcFPS
+__init__	yolov6/core/inferer.py	/^    def __init__(self, source, webcam, webcam_addr, weights, device, yaml, img_size, half):$/;"	m	class:Inferer
+__init__	yolov6/data/data_load.py	/^    def __init__(self, *args, **kwargs):$/;"	m	class:TrainValDataLoader
+__init__	yolov6/data/data_load.py	/^    def __init__(self, sampler):$/;"	m	class:_RepeatSampler
+__init__	yolov6/data/datasets.py	/^    def __init__($/;"	m	class:TrainValDataset
+__init__	yolov6/data/datasets.py	/^    def __init__(self, path, webcam, webcam_addr):$/;"	m	class:LoadData
+__init__	yolov6/layers/common.py	/^    def __init__(self, channel, reduction=4):$/;"	m	class:SEBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels):$/;"	m	class:BiFusion
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, basic_block=RepVGGBlock, weight=False):$/;"	m	class:BottleRep
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, basic_block=RepVGGBlock, weight=False):$/;"	m	class:BottleRep3
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size, stride, activation_type, padding=None, groups=1, bias=False):$/;"	m	class:ConvModule
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=2, stride=2):$/;"	m	class:Transpose
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=1,$/;"	m	class:LinearAddBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=1,$/;"	m	class:RealVGGBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=None, groups=1, bias=False):$/;"	m	class:ConvBN
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=None, groups=1, bias=False):$/;"	m	class:ConvBNHS
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=None, groups=1, bias=False):$/;"	m	class:ConvBNReLU
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=None, groups=1, bias=False):$/;"	m	class:ConvBNSiLU
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3,$/;"	m	class:QARepVGGBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3,$/;"	m	class:QARepVGGBlockV2
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=3,$/;"	m	class:RepVGGBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=5, block=ConvBNReLU):$/;"	m	class:SPPFModule
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=5, block=ConvBNReLU):$/;"	m	class:SimSPPF
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=5, block=ConvBNSiLU):$/;"	m	class:SPPF
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=5, e=0.5, block=ConvBNReLU):$/;"	m	class:CSPSPPFModule
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=5, e=0.5, block=ConvBNReLU):$/;"	m	class:SimCSPSPPF
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, kernel_size=5, e=0.5, block=ConvBNSiLU):$/;"	m	class:CSPSPPF
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, n=1, block=RepVGGBlock, basic_block=RepVGGBlock):$/;"	m	class:RepBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, n=1, e=0.5, block=RepVGGBlock):$/;"	m	class:BepC3
+__init__	yolov6/layers/common.py	/^    def __init__(self, in_channels, out_channels, n=1, e=0.5, block=RepVGGBlock):$/;"	m	class:MBLABlock
+__init__	yolov6/layers/common.py	/^    def __init__(self, num_features, use_bias=True, scale_init=1.0):$/;"	m	class:ScaleLayer
+__init__	yolov6/layers/common.py	/^    def __init__(self, weights='yolov6s.pt', device=None, dnn=True):$/;"	m	class:DetectBackend
+__init__	yolov6/layers/common.py	/^    def __init__(self,$/;"	m	class:CSPBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self,$/;"	m	class:DPBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self,$/;"	m	class:DarknetBlock
+__init__	yolov6/layers/common.py	/^    def __init__(self,$/;"	m	class:Lite_EffiBlockS1
+__init__	yolov6/layers/common.py	/^    def __init__(self,$/;"	m	class:Lite_EffiBlockS2
+__init__	yolov6/models/efficientrep.py	/^    def __init__($/;"	m	class:CSPBepBackbone
+__init__	yolov6/models/efficientrep.py	/^    def __init__($/;"	m	class:CSPBepBackbone_P6
+__init__	yolov6/models/efficientrep.py	/^    def __init__($/;"	m	class:EfficientRep
+__init__	yolov6/models/efficientrep.py	/^    def __init__($/;"	m	class:EfficientRep6
+__init__	yolov6/models/efficientrep.py	/^    def __init__(self,$/;"	m	class:Lite_EffiBackbone
+__init__	yolov6/models/effidehead.py	/^    def __init__(self, num_classes=80, num_layers=3, inplace=True, head_layers=None, use_dfl=True, reg_max=16):  # detection layer$/;"	m	class:Detect
+__init__	yolov6/models/end2end.py	/^    def __init__(self, max_obj=100, iou_thres=0.45, score_thres=0.25, device=None):$/;"	m	class:ONNX_ORT
+__init__	yolov6/models/end2end.py	/^    def __init__(self, max_obj=100, iou_thres=0.45, score_thres=0.25, device=None):$/;"	m	class:ONNX_TRT7
+__init__	yolov6/models/end2end.py	/^    def __init__(self, max_obj=100, iou_thres=0.45, score_thres=0.25, device=None):$/;"	m	class:ONNX_TRT8
+__init__	yolov6/models/end2end.py	/^    def __init__(self, model, max_obj=100, iou_thres=0.45, score_thres=0.25, device=None, ort=False,  trt_version=8, with_preprocess=False):$/;"	m	class:End2End
+__init__	yolov6/models/heads/effidehead_distill_ns.py	/^    def __init__(self, num_classes=80, num_layers=3, inplace=True, head_layers=None, use_dfl=True, reg_max=16):  # detection layer$/;"	m	class:Detect
+__init__	yolov6/models/heads/effidehead_fuseab.py	/^    def __init__(self, num_classes=80, anchors=None, num_layers=3, inplace=True, head_layers=None, use_dfl=True, reg_max=16):  # detection layer$/;"	m	class:Detect
+__init__	yolov6/models/heads/effidehead_lite.py	/^    def __init__(self, num_classes=80, num_layers=3, inplace=True, head_layers=None):  # detection layer$/;"	m	class:Detect
+__init__	yolov6/models/losses/loss.py	/^    def __init__(self):$/;"	m	class:VarifocalLoss
+__init__	yolov6/models/losses/loss.py	/^    def __init__(self, num_classes, reg_max, use_dfl=False, iou_type='giou'):$/;"	m	class:BboxLoss
+__init__	yolov6/models/losses/loss.py	/^    def __init__(self,$/;"	m	class:ComputeLoss
+__init__	yolov6/models/losses/loss_distill.py	/^    def __init__(self):$/;"	m	class:VarifocalLoss
+__init__	yolov6/models/losses/loss_distill.py	/^    def __init__(self, num_classes, reg_max, use_dfl=False, iou_type='giou'):$/;"	m	class:BboxLoss
+__init__	yolov6/models/losses/loss_distill.py	/^    def __init__(self,$/;"	m	class:ComputeLoss
+__init__	yolov6/models/losses/loss_distill_ns.py	/^    def __init__(self):$/;"	m	class:VarifocalLoss
+__init__	yolov6/models/losses/loss_distill_ns.py	/^    def __init__(self, num_classes, reg_max, use_dfl=False, iou_type='giou'):$/;"	m	class:BboxLoss
+__init__	yolov6/models/losses/loss_distill_ns.py	/^    def __init__(self,$/;"	m	class:ComputeLoss
+__init__	yolov6/models/losses/loss_fuseab.py	/^    def __init__(self):$/;"	m	class:VarifocalLoss
+__init__	yolov6/models/losses/loss_fuseab.py	/^    def __init__(self, num_classes, reg_max, use_dfl=False, iou_type='giou'):$/;"	m	class:BboxLoss
+__init__	yolov6/models/losses/loss_fuseab.py	/^    def __init__(self,$/;"	m	class:ComputeLoss
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:CSPRepBiFPANNeck
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:CSPRepBiFPANNeck_P6
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:CSPRepPANNeck
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:CSPRepPANNeck_P6
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:Lite_EffiNeck
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:RepBiFPANNeck
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:RepBiFPANNeck6
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:RepPANNeck
+__init__	yolov6/models/reppan.py	/^    def __init__($/;"	m	class:RepPANNeck6
+__init__	yolov6/models/yolo.py	/^    def __init__(self, config, channels=3, num_classes=None, fuse_ab=False, distill_ns=False):  # model, input channels, number of classes$/;"	m	class:Model
+__init__	yolov6/models/yolo_lite.py	/^    def __init__(self, config, channels=3, num_classes=None):  # model, input channels, number of classes$/;"	m	class:Model
+__init__	yolov6/utils/RepOptimizer.py	/^    def __init__(self, model, scales,$/;"	m	class:RepVGGOptimizer
+__init__	yolov6/utils/config.py	/^    def __init__(self, cfg_dict=None, cfg_text=None, filename=None):$/;"	m	class:Config
+__init__	yolov6/utils/ema.py	/^    def __init__(self, model, decay=0.9999, updates=0):$/;"	m	class:ModelEMA
+__init__	yolov6/utils/figure_iou.py	/^    def __init__(self, box_format='xywh', iou_type='ciou', reduction='none', eps=1e-7):$/;"	m	class:IOUloss
+__init__	yolov6/utils/metrics.py	/^    def __init__(self, nc, conf=0.25, iou_thres=0.45):$/;"	m	class:ConfusionMatrix
+__iter__	yolov6/data/data_load.py	/^    def __iter__(self):$/;"	m	class:TrainValDataLoader	file:
+__iter__	yolov6/data/data_load.py	/^    def __iter__(self):$/;"	m	class:_RepeatSampler	file:
+__iter__	yolov6/data/datasets.py	/^    def __iter__(self):$/;"	m	class:LoadData	file:
+__len__	deploy/TensorRT/calibrator.py	/^    def __len__(self):$/;"	m	class:DataLoader	file:
+__len__	yolov6/data/data_load.py	/^    def __len__(self):$/;"	m	class:TrainValDataLoader	file:
+__len__	yolov6/data/datasets.py	/^    def __len__(self):$/;"	m	class:LoadData	file:
+__len__	yolov6/data/datasets.py	/^    def __len__(self):$/;"	m	class:TrainValDataset	file:
+__missing__	yolov6/utils/config.py	/^    def __missing__(self, name):$/;"	m	class:ConfigDict	file:
+__next__	yolov6/data/datasets.py	/^    def __next__(self):$/;"	m	class:LoadData	file:
+__repr__	yolov6/utils/config.py	/^    def __repr__(self):$/;"	m	class:Config	file:
+__setattr__	yolov6/utils/config.py	/^    def __setattr__(self, name, value):$/;"	m	class:Config	file:
+__setstate__	yolov6/utils/RepOptimizer.py	/^    def __setstate__(self, state):$/;"	m	class:RepVGGOptimizer	file:
+_apply	yolov6/models/yolo.py	/^    def _apply(self, fn):$/;"	m	class:Model
+_apply	yolov6/models/yolo_lite.py	/^    def _apply(self, fn):$/;"	m	class:Model
+_avg_to_3x3_tensor	yolov6/layers/common.py	/^    def _avg_to_3x3_tensor(self, avgp):$/;"	m	class:RepVGGBlock
+_df_loss	yolov6/models/losses/loss.py	/^    def _df_loss(self, pred_dist, target):$/;"	m	class:BboxLoss
+_df_loss	yolov6/models/losses/loss_distill.py	/^    def _df_loss(self, pred_dist, target):$/;"	m	class:BboxLoss
+_df_loss	yolov6/models/losses/loss_distill_ns.py	/^    def _df_loss(self, pred_dist, target):$/;"	m	class:BboxLoss
+_df_loss	yolov6/models/losses/loss_fuseab.py	/^    def _df_loss(self, pred_dist, target):$/;"	m	class:BboxLoss
+_file2dict	yolov6/utils/config.py	/^    def _file2dict(filename):$/;"	m	class:Config
+_fuse_bn_tensor	yolov6/layers/common.py	/^    def _fuse_bn_tensor(self, branch):$/;"	m	class:RepVGGBlock
+_fuse_extra_bn_tensor	yolov6/layers/common.py	/^    def _fuse_extra_bn_tensor(self, kernel, bias, branch):$/;"	m	class:QARepVGGBlock
+_fuse_extra_bn_tensor	yolov6/layers/common.py	/^    def _fuse_extra_bn_tensor(self, kernel, bias, branch):$/;"	m	class:QARepVGGBlockV2
+_pad_1x1_to_3x3_tensor	yolov6/layers/common.py	/^    def _pad_1x1_to_3x3_tensor(self, kernel1x1):$/;"	m	class:RepVGGBlock
+accelerometer_orientation	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    mutable int accelerometer_orientation;$/;"	m	class:NdkCameraWindow
+accelerometer_sensor	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    const ASensor* accelerometer_sensor;$/;"	m	class:NdkCameraWindow
+accumulate	yolov6/core/inferer.py	/^    def accumulate(self):$/;"	m	class:CalcFPS
+activation_table	yolov6/layers/common.py	/^activation_table = {'relu':nn.ReLU(),$/;"	v
+add_profiles	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^def add_profiles(config, inputs, opt_profiles):$/;"	f
+add_video	yolov6/data/datasets.py	/^    def add_video(self, path):$/;"	m	class:LoadData
+after_epoch	yolov6/core/engine.py	/^    def after_epoch(self):$/;"	m	class:Trainer
+anchors	configs/base/yolov6l_base.py	/^        anchors=3,$/;"	v
+anchors	configs/base/yolov6l_base_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/base/yolov6m_base.py	/^        anchors=3,$/;"	v
+anchors	configs/base/yolov6m_base_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/base/yolov6n_base.py	/^        anchors=3,$/;"	v
+anchors	configs/base/yolov6n_base_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/base/yolov6s_base.py	/^        anchors=3,$/;"	v
+anchors	configs/base/yolov6s_base_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/experiment/yolov6n_with_eval_params.py	/^        anchors=1,$/;"	v
+anchors	configs/experiment/yolov6s_csp_scaled.py	/^        anchors=1,$/;"	v
+anchors	configs/experiment/yolov6t.py	/^        anchors=1,$/;"	v
+anchors	configs/experiment/yolov6t_csp_scaled.py	/^        anchors=1,$/;"	v
+anchors	configs/experiment/yolov6t_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/mbla/yolov6l_mbla.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6l_mbla_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6m_mbla.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6m_mbla_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6s_mbla.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6s_mbla_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6x_mbla.py	/^        anchors=3,$/;"	v
+anchors	configs/mbla/yolov6x_mbla_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/qarepvgg/yolov6m_qa.py	/^        anchors=3,$/;"	v
+anchors	configs/qarepvgg/yolov6n_qa.py	/^        anchors=3,$/;"	v
+anchors	configs/qarepvgg/yolov6s_qa.py	/^        anchors=3,$/;"	v
+anchors	configs/repopt/yolov6_tiny_hs.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6_tiny_opt.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6_tiny_opt_qat.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6n_hs.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6n_opt.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6n_opt_qat.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6s_hs.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6s_opt.py	/^        anchors=1,$/;"	v
+anchors	configs/repopt/yolov6s_opt_qat.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6_lite/yolov6_lite_l.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6_lite/yolov6_lite_m.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6_lite/yolov6_lite_s.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6l.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6l6.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6l6_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6l_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6m.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6m6.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6m6_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6m_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6n.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6n6.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6n6_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6n_finetune.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6s.py	/^        anchors=3,$/;"	v
+anchors	configs/yolov6s6.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6s6_finetune.py	/^        anchors=1,$/;"	v
+anchors	configs/yolov6s_finetune.py	/^        anchors=3,$/;"	v
+anchors_init	configs/base/yolov6l_base.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/base/yolov6m_base.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/base/yolov6m_base_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/base/yolov6n_base.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/base/yolov6n_base_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/base/yolov6s_base.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/base/yolov6s_base_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6l_mbla.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6l_mbla_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6m_mbla.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6m_mbla_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6s_mbla.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6s_mbla_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6x_mbla.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/mbla/yolov6x_mbla_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/qarepvgg/yolov6m_qa.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/qarepvgg/yolov6n_qa.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/qarepvgg/yolov6s_qa.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6l.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6l_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6m.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6m_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6n.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6n_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6s.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+anchors_init	configs/yolov6s_finetune.py	/^        anchors_init=[[10,13, 19,19, 33,23],$/;"	v
+ap_per_class	yolov6/utils/metrics.py	/^def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names=()):$/;"	f
+arg	tools/quantization/ppq/write_qparams_onnx2trt.py	/^    arg = parser.parse_args()$/;"	v
+args	deploy/NCNN/export_torchscript.py	/^    args = parser.parse_args()$/;"	v
+args	deploy/ONNX/OpenCV/yolo.py	/^	args = parser.parse_args()$/;"	v
+args	deploy/ONNX/OpenCV/yolo_video.py	/^    args = parser.parse_args()$/;"	v
+args	deploy/ONNX/OpenCV/yolox.py	/^    args = parser.parse_args()$/;"	v	class:yolox
+args	deploy/ONNX/export_onnx.py	/^    args = parser.parse_args()$/;"	v
+args	deploy/OpenVINO/export_openvino.py	/^    args = parser.parse_args()$/;"	v
+args	tools/partial_quantization/partial_quant.py	/^    args = parser.parse_args()$/;"	v
+args	tools/partial_quantization/sensitivity_analyse.py	/^    args = parser.parse_args()$/;"	v
+args	tools/qat/qat_export.py	/^    args = parser.parse_args()$/;"	v
+args	tools/train.py	/^    args = get_args_parser().parse_args()$/;"	v
+args	yolov6/data/vis_dataset.py	/^    args = parser.parse_args()$/;"	v
+args	yolov6/data/voc2yolo.py	/^    args = parser.parse_args()$/;"	v
+atss_warmup_epoch	configs/base/yolov6l_base.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/base/yolov6m_base.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/base/yolov6m_base_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/base/yolov6n_base.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/base/yolov6n_base_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/base/yolov6s_base.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/base/yolov6s_base_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6l_mbla.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6l_mbla_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6m_mbla.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6m_mbla_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6s_mbla.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6s_mbla_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6x_mbla.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/mbla/yolov6x_mbla_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/qarepvgg/yolov6m_qa.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/qarepvgg/yolov6n_qa.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/qarepvgg/yolov6s_qa.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6_tiny_hs.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6_tiny_opt.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6_tiny_opt_qat.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6n_hs.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6n_opt.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6n_opt_qat.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6s_hs.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6s_opt.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/repopt/yolov6s_opt_qat.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6_lite/yolov6_lite_l.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6_lite/yolov6_lite_m.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6_lite/yolov6_lite_s.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6l.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6l6.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6l6_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6l_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6m.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6m6.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6m6_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6m_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6n.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6n6.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6n6_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6n_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6s.py	/^        atss_warmup_epoch=0,$/;"	v
+atss_warmup_epoch	configs/yolov6s6.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6s6_finetune.py	/^        atss_warmup_epoch=4,$/;"	v
+atss_warmup_epoch	configs/yolov6s_finetune.py	/^        atss_warmup_epoch=0,$/;"	v
+augment	tools/partial_quantization/sensitivity_analyse.py	/^        augment=True,$/;"	v
+augment_hsv	yolov6/data/data_augment.py	/^def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):$/;"	f
+avg_time	deploy/ONNX/OpenCV/yolo.py	/^	avg_time = total_time \/ cycles$/;"	v
+avg_time	deploy/ONNX/OpenCV/yolox.py	/^    avg_time = total_time \/ cycles$/;"	v	class:yolox
+backbone	configs/base/yolov6l_base.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6l_base_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6m_base.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6m_base_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6n_base.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6n_base_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6s_base.py	/^    backbone=dict($/;"	v
+backbone	configs/base/yolov6s_base_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/experiment/yolov6n_with_eval_params.py	/^    backbone=dict($/;"	v
+backbone	configs/experiment/yolov6s_csp_scaled.py	/^    backbone=dict($/;"	v
+backbone	configs/experiment/yolov6t.py	/^    backbone=dict($/;"	v
+backbone	configs/experiment/yolov6t_csp_scaled.py	/^    backbone=dict($/;"	v
+backbone	configs/experiment/yolov6t_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6l_mbla.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6l_mbla_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6m_mbla.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6m_mbla_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6s_mbla.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6s_mbla_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6x_mbla.py	/^    backbone=dict($/;"	v
+backbone	configs/mbla/yolov6x_mbla_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/qarepvgg/yolov6m_qa.py	/^    backbone=dict($/;"	v
+backbone	configs/qarepvgg/yolov6n_qa.py	/^    backbone=dict($/;"	v
+backbone	configs/qarepvgg/yolov6s_qa.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6_tiny_hs.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6_tiny_opt.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6_tiny_opt_qat.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6n_hs.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6n_opt.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6n_opt_qat.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6s_hs.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6s_opt.py	/^    backbone=dict($/;"	v
+backbone	configs/repopt/yolov6s_opt_qat.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6_lite/yolov6_lite_l.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6_lite/yolov6_lite_m.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6_lite/yolov6_lite_s.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6l.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6l6.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6l6_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6l_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6m.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6m6.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6m6_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6m_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6n.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6n6.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6n6_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6n_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6s.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6s6.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6s6_finetune.py	/^    backbone=dict($/;"	v
+backbone	configs/yolov6s_finetune.py	/^    backbone=dict($/;"	v
+batch_size	configs/experiment/yolov6n_with_eval_params.py	/^    batch_size=None,  #None mean will be the same as batch on one device * 2$/;"	v
+batch_size	tools/partial_quantization/sensitivity_analyse.py	/^        batch_size=args.batch_size,$/;"	v
+bbox2dist	yolov6/utils/general.py	/^def bbox2dist(anchor_points, bbox, reg_max):$/;"	f
+bbox_decode	yolov6/models/losses/loss.py	/^    def bbox_decode(self, anchor_points, pred_dist):$/;"	m	class:ComputeLoss
+bbox_decode	yolov6/models/losses/loss_distill.py	/^    def bbox_decode(self, anchor_points, pred_dist):$/;"	m	class:ComputeLoss
+bbox_decode	yolov6/models/losses/loss_distill_ns.py	/^    def bbox_decode(self, anchor_points, pred_dist):$/;"	m	class:ComputeLoss
+bbox_decode	yolov6/models/losses/loss_fuseab.py	/^    def bbox_decode(self, anchor_points, pred_dist):$/;"	m	class:ComputeLoss
+bbox_overlaps	yolov6/assigners/iou2d_calculator.py	/^def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):$/;"	f
+before_epoch	yolov6/core/engine.py	/^    def before_epoch(self):$/;"	m	class:Trainer
+before_train_loop	yolov6/core/engine.py	/^    def before_train_loop(self):$/;"	m	class:Trainer
+begin_indices	configs/base/yolov6l_base.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6l_base_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6m_base.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6m_base_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6n_base.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6n_base_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6s_base.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/base/yolov6s_base_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/experiment/yolov6n_with_eval_params.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/experiment/yolov6s_csp_scaled.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/experiment/yolov6t.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/experiment/yolov6t_csp_scaled.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/experiment/yolov6t_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6l_mbla.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6l_mbla_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6m_mbla.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6m_mbla_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6s_mbla.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6s_mbla_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6x_mbla.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/mbla/yolov6x_mbla_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/qarepvgg/yolov6m_qa.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/qarepvgg/yolov6n_qa.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/qarepvgg/yolov6s_qa.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6_tiny_hs.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6_tiny_opt.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6_tiny_opt_qat.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6n_hs.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6n_opt.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6n_opt_qat.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6s_hs.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6s_opt.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/repopt/yolov6s_opt_qat.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6l.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6l_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6m.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6m_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6n.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6n_finetune.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6s.py	/^        begin_indices=24,$/;"	v
+begin_indices	configs/yolov6s_finetune.py	/^        begin_indices=24,$/;"	v
+blobFromImage	deploy/TensorRT/yolov6.cpp	/^float* blobFromImage(cv::Mat& img){$/;"	f
+blob_pool_allocator	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    ncnn::UnlockedPoolAllocator blob_pool_allocator;$/;"	m	class:Yolo
+boolean_string	tools/eval.py	/^def boolean_string(s):$/;"	f
+boundary	tools/partial_quantization/partial_quant.py	/^    boundary = args.quant_boundary$/;"	v
+box_area	yolov6/utils/general.py	/^    def box_area(box):$/;"	f	function:box_iou
+box_candidates	yolov6/data/data_augment.py	/^def box_candidates(box1, box2, wh_thr=2, ar_thr=20, area_thr=0.1, eps=1e-16):  # box1(4,n), box2(4,n)$/;"	f
+box_convert	yolov6/core/evaler.py	/^    def box_convert(self, x):$/;"	m	class:Evaler
+box_convert	yolov6/core/inferer.py	/^    def box_convert(x):$/;"	m	class:Inferer
+box_iou	yolov6/utils/general.py	/^def box_iou(box1, box2):$/;"	f
+build_block	yolov6/models/efficientrep.py	/^    def build_block(num_repeat, in_channels, mid_channels, out_channels):$/;"	m	class:Lite_EffiBackbone
+build_effidehead_layer	yolov6/models/effidehead.py	/^def build_effidehead_layer(channels_list, num_anchors, num_classes, reg_max=16, num_layers=3):$/;"	f
+build_effidehead_layer	yolov6/models/heads/effidehead_distill_ns.py	/^def build_effidehead_layer(channels_list, num_anchors, num_classes, reg_max=16):$/;"	f
+build_effidehead_layer	yolov6/models/heads/effidehead_fuseab.py	/^def build_effidehead_layer(channels_list, num_anchors, num_classes, reg_max=16, num_layers=3):$/;"	f
+build_effidehead_layer	yolov6/models/heads/effidehead_lite.py	/^def build_effidehead_layer(channels_list, num_anchors, num_classes, num_layers):$/;"	f
+build_engine	tools/quantization/ppq/write_qparams_onnx2trt.py	/^def build_engine(onnx_file, json_file, engine_file):$/;"	f
+build_engine_from_onnx	deploy/TensorRT/onnx_to_trt.py	/^def build_engine_from_onnx(model_name,$/;"	f
+build_lr_scheduler	yolov6/solver/build.py	/^def build_lr_scheduler(cfg, optimizer, epochs):$/;"	f
+build_model	yolov6/models/yolo.py	/^def build_model(cfg, num_classes, device, fuse_ab=False, distill_ns=False):$/;"	f
+build_model	yolov6/models/yolo_lite.py	/^def build_model(cfg, num_classes, device):$/;"	f
+build_network	yolov6/models/yolo.py	/^def build_network(config, channels, num_classes, num_layers, fuse_ab=False, distill_ns=False):$/;"	f
+build_network	yolov6/models/yolo_lite.py	/^def build_network(config, in_channels, num_classes):$/;"	f
+build_optimizer	yolov6/solver/build.py	/^def build_optimizer(cfg, model):$/;"	f
+cache_images	yolov6/data/datasets.py	/^    def cache_images(self, num_imgs=None):$/;"	m	class:TrainValDataset
+cal_cache_occupy	yolov6/data/datasets.py	/^    def cal_cache_occupy(self, num_imgs):$/;"	m	class:TrainValDataset
+calib_batches	configs/repopt/yolov6_tiny_opt_qat.py	/^    calib_batches = 4,$/;"	v
+calib_batches	configs/repopt/yolov6n_opt_qat.py	/^    calib_batches = 4,$/;"	v
+calib_batches	configs/repopt/yolov6s_opt_qat.py	/^    calib_batches = 4,$/;"	v
+calib_method	configs/repopt/yolov6_tiny_opt_qat.py	/^    calib_method = 'max',$/;"	v
+calib_method	configs/repopt/yolov6n_opt_qat.py	/^    calib_method = 'max',$/;"	v
+calib_method	configs/repopt/yolov6s_opt_qat.py	/^    calib_method = 'histogram',$/;"	v
+calib_output_path	configs/repopt/yolov6_tiny_opt_qat.py	/^    calib_output_path='.\/',$/;"	v
+calib_output_path	configs/repopt/yolov6n_opt_qat.py	/^    calib_output_path='.\/',$/;"	v
+calib_output_path	configs/repopt/yolov6s_opt_qat.py	/^    calib_output_path='.\/',$/;"	v
+calib_pt	configs/repopt/yolov6_tiny_opt_qat.py	/^    calib_pt = '.\/assets\/v6s_t_calib_max.pt',$/;"	v
+calib_pt	configs/repopt/yolov6n_opt_qat.py	/^    calib_pt = '.\/assets\/v6s_n_calib_max.pt',$/;"	v
+calib_pt	configs/repopt/yolov6s_opt_qat.py	/^    calib_pt = '.\/assets\/yolov6s_v2_reopt_43.1_calib_histogram.pt',$/;"	v
+calibrate	yolov6/core/engine.py	/^    def calibrate(self, cfg):$/;"	m	class:Trainer
+cameraView	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private SurfaceView cameraView;$/;"	f	class:MainActivity	file:
+camera_device	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACameraDevice* camera_device;$/;"	m	class:NdkCamera
+camera_facing	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    int camera_facing;$/;"	m	class:NdkCamera
+camera_manager	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACameraManager* camera_manager;$/;"	m	class:NdkCamera
+camera_orientation	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    int camera_orientation;$/;"	m	class:NdkCamera
+cap	deploy/ONNX/OpenCV/yolo_video.py	/^    cap = cv2.VideoCapture(video_source)$/;"	v
+capture_request	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACaptureRequest* capture_request;$/;"	m	class:NdkCamera
+capture_session	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACameraCaptureSession* capture_session;$/;"	m	class:NdkCamera
+capture_session_output	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACaptureSessionOutput* capture_session_output;$/;"	m	class:NdkCamera
+capture_session_output_container	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACaptureSessionOutputContainer* capture_session_output_container;$/;"	m	class:NdkCamera
+cast_tensor_type	yolov6/assigners/iou2d_calculator.py	/^def cast_tensor_type(x, scale=1., dtype=None):$/;"	f
+cfg	tools/partial_quantization/sensitivity_analyse.py	/^    cfg = Config.fromfile(args.conf)$/;"	v
+cfg	tools/qat/qat_export.py	/^    cfg = Config.fromfile(args.conf)$/;"	v
+channel_shuffle	yolov6/layers/common.py	/^def channel_shuffle(x, groups):$/;"	f
+check_and_init	tools/train.py	/^def check_and_init(args):$/;"	f
+check_args	deploy/TensorRT/eval_yolo_trt.py	/^def check_args(args):$/;"	f
+check_args	deploy/TensorRT/visualize.py	/^def check_args(args):$/;"	f
+check_image	yolov6/data/datasets.py	/^    def check_image(im_file):$/;"	m	class:TrainValDataset
+check_img_size	hubconf.py	/^def check_img_size(img_size, s=32, floor=0):$/;"	f
+check_img_size	yolov6/core/inferer.py	/^    def check_img_size(self, img_size, s=32, floor=0):$/;"	m	class:Inferer
+check_img_size	yolov6/utils/general.py	/^def check_img_size(imgsz, s=32, floor=0):$/;"	f
+check_keywords_in_name	yolov6/utils/RepOptimizer.py	/^def check_keywords_in_name(name, keywords=()):$/;"	f
+check_label_files	yolov6/data/datasets.py	/^    def check_label_files(args):$/;"	m	class:TrainValDataset
+check_network	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^def check_network(network):$/;"	f
+check_task	yolov6/core/evaler.py	/^    def check_task(task):$/;"	m	class:Evaler
+check_thres	yolov6/core/evaler.py	/^    def check_thres(conf_thres, iou_thres, task):$/;"	m	class:Evaler
+check_version	yolov6/utils/general.py	/^def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=False, hard=False, verbose=False):$/;"	f
+checkext	yolov6/data/datasets.py	/^    def checkext(self, path):$/;"	m	class:LoadData
+ckpt	tools/qat/qat_export.py	/^    ckpt = torch.load(args.quant_weights)$/;"	v
+class_names	deploy/TensorRT/yolov6.cpp	/^static const char* class_names[] = {$/;"	v	file:
+classes	deploy/ONNX/OpenCV/yolo.py	/^		classes = f.read().rstrip('\\n').split('\\n')$/;"	v
+classes	deploy/ONNX/OpenCV/yolo.py	/^	classes = None$/;"	v
+classes	deploy/ONNX/OpenCV/yolo_video.py	/^        classes = f.read().rstrip('\\n').split('\\n')$/;"	v
+classes	deploy/ONNX/OpenCV/yolo_video.py	/^    classes = None$/;"	v
+classes	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	vector<string> classes;$/;"	m	class:yolox	file:
+classesFile	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	string classesFile;$/;"	m	class:yolox	file:
+close	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void NdkCamera::close()$/;"	f	class:NdkCamera
+closeCamera	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/Yolov6Ncnn.java	/^    public native boolean closeCamera();$/;"	m	class:Yolov6Ncnn
+cmd	deploy/OpenVINO/export_openvino.py	/^        cmd = f"mo --input_model {import_file} --output_dir {export_dir} --data_type {'FP16' if args.half else 'FP32'}"$/;"	v
+coco80_to_coco91_class	yolov6/core/evaler.py	/^    def coco80_to_coco91_class():  # converts 80-index (val2014) to 91-index (paper)$/;"	m	class:Evaler
+collate_fn	tools/quantization/ppq/ProgramEntrance.py	/^collate_fn = lambda x: x.cuda()$/;"	v
+collate_fn	yolov6/data/datasets.py	/^    def collate_fn(batch):$/;"	m	class:TrainValDataset
+collect_stats	tools/partial_quantization/ptq.py	/^def collect_stats(model, data_loader, batch_number, device='cuda'):$/;"	f
+collect_stats	tools/qat/qat_utils.py	/^def collect_stats(model, data_loader, num_batches):$/;"	f
+color_list	deploy/TensorRT/yolov6.cpp	/^const float color_list[80][3] =$/;"	v
+com.tencent.yolov6ncnn	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^package com.tencent.yolov6ncnn;$/;"	p
+com.tencent.yolov6ncnn	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/Yolov6Ncnn.java	/^package com.tencent.yolov6ncnn;$/;"	p
+compute_amax	tools/partial_quantization/ptq.py	/^def compute_amax(model, **kwargs):$/;"	f
+compute_amax	tools/qat/qat_utils.py	/^def compute_amax(model, **kwargs):$/;"	f
+compute_ap	yolov6/utils/metrics.py	/^def compute_ap(recall, precision):$/;"	f
+concat_quant_amax_fuse	tools/partial_quantization/utils.py	/^def concat_quant_amax_fuse(ops_list):$/;"	f
+conf_thres	configs/experiment/yolov6n_with_eval_params.py	/^    conf_thres=0.03,$/;"	v
+convert_box	yolov6/data/voc2yolo.py	/^    def convert_box(size, box):$/;"	f	function:convert_label
+convert_label	yolov6/data/voc2yolo.py	/^def convert_label(path, lb_path, year, image_id):$/;"	f
+convert_to_coco_format	yolov6/core/evaler.py	/^    def convert_to_coco_format(self, outputs, imgs, paths, shapes, ids, task):$/;"	m	class:Evaler
+convert_to_coco_format_trt	yolov6/core/evaler.py	/^        def convert_to_coco_format_trt(nums, boxes, scores, classes, paths, shapes, ids):$/;"	f	function:Evaler.eval_trt
+copy_attr	yolov6/utils/ema.py	/^def copy_attr(a, b, include=(), exclude=()):$/;"	f
+create_dataloader	yolov6/data/data_load.py	/^def create_dataloader($/;"	f
+create_model	hubconf.py	/^def create_model(model_name, class_names=CLASS_NAMES, device=DEVICE,$/;"	f
+create_optimization_profiles	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^def create_optimization_profiles(builder, inputs, batch_sizes=[1,8,16,32,64]):$/;"	f
+csp_e	configs/base/yolov6l_base.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/base/yolov6l_base_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/base/yolov6m_base.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/base/yolov6m_base_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/base/yolov6s_base.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/base/yolov6s_base_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/experiment/yolov6s_csp_scaled.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/experiment/yolov6t_csp_scaled.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6l_mbla.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6l_mbla_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6m_mbla.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6m_mbla_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6s_mbla.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6s_mbla_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6x_mbla.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/mbla/yolov6x_mbla_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/qarepvgg/yolov6m_qa.py	/^        csp_e=float(2)\/3,$/;"	v
+csp_e	configs/yolov6l.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/yolov6l6.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/yolov6l6_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/yolov6l_finetune.py	/^        csp_e=float(1)\/2,$/;"	v
+csp_e	configs/yolov6m.py	/^        csp_e=float(2)\/3,$/;"	v
+csp_e	configs/yolov6m6.py	/^        csp_e=float(2)\/3,$/;"	v
+csp_e	configs/yolov6m6_finetune.py	/^        csp_e=float(2)\/3,$/;"	v
+csp_e	configs/yolov6m_finetune.py	/^        csp_e=float(2)\/3,$/;"	v
+cspsppf	configs/base/yolov6n_base.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/base/yolov6n_base_finetune.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/base/yolov6s_base.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/base/yolov6s_base_finetune.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/qarepvgg/yolov6n_qa.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/qarepvgg/yolov6s_qa.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6n.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6n6.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6n6_finetune.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6n_finetune.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6s.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6s6.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6s6_finetune.py	/^        cspsppf=True,$/;"	v
+cspsppf	configs/yolov6s_finetune.py	/^        cspsppf=True,$/;"	v
+current_cpugpu	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private int current_cpugpu = 0;$/;"	f	class:MainActivity	file:
+current_model	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private int current_model = 0;$/;"	f	class:MainActivity	file:
+custom	hubconf.py	/^def custom(ckpt_path, class_names, device=DEVICE, img_size=640, conf_thres=0.25, iou_thres=0.45, max_det=1000):$/;"	f
+cycles	deploy/ONNX/OpenCV/yolo.py	/^	cycles = 300$/;"	v
+cycles	deploy/ONNX/OpenCV/yolox.py	/^    cycles = 300$/;"	v	class:yolox
+data_aug	configs/base/yolov6l_base.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6l_base_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6m_base.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6m_base_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6n_base.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6n_base_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6s_base.py	/^data_aug = dict($/;"	v
+data_aug	configs/base/yolov6s_base_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/experiment/yolov6n_with_eval_params.py	/^data_aug = dict($/;"	v
+data_aug	configs/experiment/yolov6s_csp_scaled.py	/^data_aug = dict($/;"	v
+data_aug	configs/experiment/yolov6t.py	/^data_aug = dict($/;"	v
+data_aug	configs/experiment/yolov6t_csp_scaled.py	/^data_aug = dict($/;"	v
+data_aug	configs/experiment/yolov6t_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6l_mbla.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6l_mbla_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6m_mbla.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6m_mbla_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6s_mbla.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6s_mbla_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6x_mbla.py	/^data_aug = dict($/;"	v
+data_aug	configs/mbla/yolov6x_mbla_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/qarepvgg/yolov6m_qa.py	/^data_aug = dict($/;"	v
+data_aug	configs/qarepvgg/yolov6n_qa.py	/^data_aug = dict($/;"	v
+data_aug	configs/qarepvgg/yolov6s_qa.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6_tiny_hs.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6_tiny_opt.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6_tiny_opt_qat.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6n_hs.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6n_opt.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6n_opt_qat.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6s_hs.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6s_opt.py	/^data_aug = dict($/;"	v
+data_aug	configs/repopt/yolov6s_opt_qat.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6_lite/yolov6_lite_l.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6_lite/yolov6_lite_m.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6_lite/yolov6_lite_s.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6l.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6l6.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6l6_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6l_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6m.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6m6.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6m6_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6m_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6n.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6n6.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6n6_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6n_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6s.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6s6.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6s6_finetune.py	/^data_aug = dict($/;"	v
+data_aug	configs/yolov6s_finetune.py	/^data_aug = dict($/;"	v
+data_cfg	tools/partial_quantization/sensitivity_analyse.py	/^    data_cfg = load_yaml(args.data_yaml)$/;"	v
+data_dict	tools/partial_quantization/sensitivity_analyse.py	/^        data_dict=data_cfg)$/;"	v
+dataset	tools/quantization/ppq/ProgramEntrance.py	/^dataset = [torch.rand(size=[1, 3, 640, 640]) for _ in range(64)]$/;"	v
+datefmt	tools/quantization/tensorrt/post_training/Calibrator.py	/^                    datefmt="%Y-%m-%d %H:%M:%S")$/;"	v
+datefmt	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^                    datefmt="%Y-%m-%d %H:%M:%S")$/;"	v
+de_parallel	yolov6/utils/ema.py	/^def de_parallel(model):$/;"	f
+decode_outputs	deploy/TensorRT/yolov6.cpp	/^static void decode_outputs(float* prob, int output_size, std::vector<Object>& objects, float scale, const int img_w, const int img_h) {$/;"	f	file:
+default	configs/experiment/eval_640_repro.py	/^    default = dict($/;"	v
+defineTest	deploy/TensorRT/logging.h	/^    static TestAtom defineTest(const std::string& name, const std::string& cmdline)$/;"	f	class:Logger
+defineTest	deploy/TensorRT/logging.h	/^    static TestAtom defineTest(const std::string& name, int argc, char const* const* argv)$/;"	f	class:Logger
+degrees	configs/base/yolov6l_base.py	/^    degrees=0.0,$/;"	v
+degrees	configs/base/yolov6l_base_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/base/yolov6m_base.py	/^    degrees=0.0,$/;"	v
+degrees	configs/base/yolov6m_base_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/base/yolov6n_base.py	/^    degrees=0.0,$/;"	v
+degrees	configs/base/yolov6n_base_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/base/yolov6s_base.py	/^    degrees=0.0,$/;"	v
+degrees	configs/base/yolov6s_base_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/experiment/yolov6n_with_eval_params.py	/^    degrees=0.0,$/;"	v
+degrees	configs/experiment/yolov6s_csp_scaled.py	/^    degrees=0.0,$/;"	v
+degrees	configs/experiment/yolov6t.py	/^    degrees=0.0,$/;"	v
+degrees	configs/experiment/yolov6t_csp_scaled.py	/^    degrees=0.0,$/;"	v
+degrees	configs/experiment/yolov6t_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/mbla/yolov6l_mbla.py	/^    degrees=0.0,$/;"	v
+degrees	configs/mbla/yolov6l_mbla_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/mbla/yolov6m_mbla.py	/^    degrees=0.0,$/;"	v
+degrees	configs/mbla/yolov6m_mbla_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/mbla/yolov6s_mbla.py	/^    degrees=0.0,$/;"	v
+degrees	configs/mbla/yolov6s_mbla_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/mbla/yolov6x_mbla.py	/^    degrees=0.0,$/;"	v
+degrees	configs/mbla/yolov6x_mbla_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/qarepvgg/yolov6m_qa.py	/^    degrees=0.0,$/;"	v
+degrees	configs/qarepvgg/yolov6n_qa.py	/^    degrees=0.0,$/;"	v
+degrees	configs/qarepvgg/yolov6s_qa.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6_tiny_hs.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6_tiny_opt.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6_tiny_opt_qat.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6n_hs.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6n_opt.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6n_opt_qat.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6s_hs.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6s_opt.py	/^    degrees=0.0,$/;"	v
+degrees	configs/repopt/yolov6s_opt_qat.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6_lite/yolov6_lite_l.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6_lite/yolov6_lite_m.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6_lite/yolov6_lite_s.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6l.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6l6.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6l6_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6l_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6m.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6m6.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6m6_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6m_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6n.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6n6.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6n6_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6n_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6s.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6s6.py	/^    degrees=0.0,$/;"	v
+degrees	configs/yolov6s6_finetune.py	/^    degrees=0.373,$/;"	v
+degrees	configs/yolov6s_finetune.py	/^    degrees=0.373,$/;"	v
+demo_postprocess	deploy/ONNX/OpenCV/yolox.py	/^    def demo_postprocess(self, outputs):$/;"	m	class:yolox
+depth_multiple	configs/base/yolov6l_base.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/base/yolov6l_base_finetune.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/base/yolov6m_base.py	/^    depth_multiple=0.80,$/;"	v
+depth_multiple	configs/base/yolov6m_base_finetune.py	/^    depth_multiple=0.80,$/;"	v
+depth_multiple	configs/base/yolov6n_base.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/base/yolov6n_base_finetune.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/base/yolov6s_base.py	/^    depth_multiple=0.70,$/;"	v
+depth_multiple	configs/base/yolov6s_base_finetune.py	/^    depth_multiple=0.70,$/;"	v
+depth_multiple	configs/experiment/yolov6n_with_eval_params.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/experiment/yolov6s_csp_scaled.py	/^    depth_multiple=0.70,$/;"	v
+depth_multiple	configs/experiment/yolov6t.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/experiment/yolov6t_csp_scaled.py	/^    depth_multiple=0.60,$/;"	v
+depth_multiple	configs/experiment/yolov6t_finetune.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/mbla/yolov6l_mbla.py	/^    depth_multiple=0.5,$/;"	v
+depth_multiple	configs/mbla/yolov6l_mbla_finetune.py	/^    depth_multiple=0.5,$/;"	v
+depth_multiple	configs/mbla/yolov6m_mbla.py	/^    depth_multiple=0.5,$/;"	v
+depth_multiple	configs/mbla/yolov6m_mbla_finetune.py	/^    depth_multiple=0.5,$/;"	v
+depth_multiple	configs/mbla/yolov6s_mbla.py	/^    depth_multiple=0.5,$/;"	v
+depth_multiple	configs/mbla/yolov6s_mbla_finetune.py	/^    depth_multiple=0.5,$/;"	v
+depth_multiple	configs/mbla/yolov6x_mbla.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/mbla/yolov6x_mbla_finetune.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/qarepvgg/yolov6m_qa.py	/^    depth_multiple=0.60,$/;"	v
+depth_multiple	configs/qarepvgg/yolov6n_qa.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/qarepvgg/yolov6s_qa.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6_tiny_hs.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6_tiny_opt.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6_tiny_opt_qat.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6n_hs.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6n_opt.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6n_opt_qat.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6s_hs.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6s_opt.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/repopt/yolov6s_opt_qat.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6l.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/yolov6l6.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/yolov6l6_finetune.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/yolov6l_finetune.py	/^    depth_multiple=1.0,$/;"	v
+depth_multiple	configs/yolov6m.py	/^    depth_multiple=0.60,$/;"	v
+depth_multiple	configs/yolov6m6.py	/^    depth_multiple=0.60,$/;"	v
+depth_multiple	configs/yolov6m6_finetune.py	/^    depth_multiple=0.60,$/;"	v
+depth_multiple	configs/yolov6m_finetune.py	/^    depth_multiple=0.60,$/;"	v
+depth_multiple	configs/yolov6n.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6n6.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6n6_finetune.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6n_finetune.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6s.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6s6.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6s6_finetune.py	/^    depth_multiple=0.33,$/;"	v
+depth_multiple	configs/yolov6s_finetune.py	/^    depth_multiple=0.33,$/;"	v
+detect	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^int Yolo::detect(const cv::Mat& rgb, std::vector<Object>& objects, float prob_threshold, float nms_threshold)$/;"	f	class:Yolo
+detect	deploy/ONNX/OpenCV/yolox.py	/^    def detect(self, srcimg):$/;"	m	class:yolox
+detect	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^void yolox::detect(Mat& srcimg)$/;"	f	class:yolox
+detect	deploy/TensorRT/Processor.py	/^    def detect(self, img):$/;"	m	class:Processor
+detect	deploy/TensorRT/tensorrt_processor.py	/^    def detect(self, img):$/;"	m	class:Processor
+detections	deploy/ONNX/OpenCV/yolo.py	/^		detections = pre_process(input.copy(), net)$/;"	v
+device	deploy/NCNN/export_torchscript.py	/^    device = torch.device(f'cuda:{args.device}' if cuda else 'cpu')$/;"	v
+device	deploy/ONNX/export_onnx.py	/^    device = torch.device(f'cuda:{args.device}' if cuda else 'cpu')$/;"	v
+device	deploy/OpenVINO/export_openvino.py	/^    device = torch.device('cuda:0' if cuda else 'cpu')$/;"	v
+device	tools/partial_quantization/partial_quant.py	/^    device = torch.device('cuda:0' if cuda else 'cpu')$/;"	v
+device	tools/partial_quantization/sensitivity_analyse.py	/^    device = torch.device('cuda:0' if cuda else 'cpu')$/;"	v
+device	tools/qat/qat_export.py	/^    device = torch.device('cuda:0' if cuda else 'cpu')$/;"	v
+die	deploy/NCNN/Android/gradlew	/^die () {$/;"	f
+dispatching	tools/quantization/ppq/ProgramEntrance.py	/^dispatching = PFL.Dispatcher(graph=graph).dispatch(                       # 生成调度表$/;"	v
+dist2bbox	yolov6/utils/general.py	/^def dist2bbox(distance, anchor_points, box_format='xyxy'):$/;"	f
+dist_calculator	yolov6/assigners/assigner_utils.py	/^def dist_calculator(gt_bboxes, anchor_bboxes):$/;"	f
+distill_loss_cls	yolov6/models/losses/loss_distill.py	/^    def distill_loss_cls(self, logits_student, logits_teacher, num_classes, temperature=20):$/;"	m	class:ComputeLoss
+distill_loss_cls	yolov6/models/losses/loss_distill_ns.py	/^    def distill_loss_cls(self, logits_student, logits_teacher, num_classes, temperature=20):$/;"	m	class:ComputeLoss
+distill_loss_cw	yolov6/models/losses/loss_distill.py	/^    def distill_loss_cw(self, s_feats, t_feats,  temperature=1):$/;"	m	class:ComputeLoss
+distill_loss_cw	yolov6/models/losses/loss_distill_ns.py	/^    def distill_loss_cw(self, s_feats, t_feats,  temperature=1):$/;"	m	class:ComputeLoss
+distill_loss_dfl	yolov6/models/losses/loss_distill.py	/^    def distill_loss_dfl(self, logits_student, logits_teacher, temperature=20):$/;"	m	class:BboxLoss
+distill_loss_dfl	yolov6/models/losses/loss_distill_ns.py	/^    def distill_loss_dfl(self, logits_student, logits_teacher, temperature=20):$/;"	m	class:BboxLoss
+distill_weight	configs/base/yolov6l_base.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6l_base_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6m_base.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6m_base_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6n_base.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6n_base_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6s_base.py	/^        distill_weight={$/;"	v
+distill_weight	configs/base/yolov6s_base_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6l_mbla.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6l_mbla_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6m_mbla.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6m_mbla_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6s_mbla.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6s_mbla_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6x_mbla.py	/^        distill_weight={$/;"	v
+distill_weight	configs/mbla/yolov6x_mbla_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/qarepvgg/yolov6m_qa.py	/^        distill_weight={$/;"	v
+distill_weight	configs/qarepvgg/yolov6n_qa.py	/^        distill_weight={$/;"	v
+distill_weight	configs/qarepvgg/yolov6s_qa.py	/^        distill_weight={$/;"	v
+distill_weight	configs/repopt/yolov6_tiny_opt_qat.py	/^        distill_weight={$/;"	v
+distill_weight	configs/repopt/yolov6n_opt_qat.py	/^        distill_weight={$/;"	v
+distill_weight	configs/repopt/yolov6s_opt_qat.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6l.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6l6.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6l6_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6l_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6m.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6m6.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6m6_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6m_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6n.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6n_finetune.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6s.py	/^        distill_weight={$/;"	v
+distill_weight	configs/yolov6s_finetune.py	/^        distill_weight={$/;"	v
+doInference	deploy/TensorRT/yolov6.cpp	/^void doInference(IExecutionContext& context, float* input, float* output, const int output_size, cv::Size input_shape) {$/;"	f
+do_coco_metric	configs/experiment/yolov6n_with_eval_params.py	/^    do_coco_metric=True,$/;"	v
+do_constant_folding	deploy/ONNX/export_onnx.py	/^                              do_constant_folding=True,$/;"	v
+do_constant_folding	deploy/OpenVINO/export_openvino.py	/^                          do_constant_folding=True,$/;"	v
+do_constant_folding	tools/partial_quantization/partial_quant.py	/^                          do_constant_folding=True,$/;"	v
+do_constant_folding	tools/qat/qat_export.py	/^                          do_constant_folding=True,$/;"	v
+do_pr_metric	configs/experiment/yolov6n_with_eval_params.py	/^    do_pr_metric=False,$/;"	v
+do_ptq	tools/partial_quantization/ptq.py	/^def do_ptq(model, train_loader, batch_number, device):$/;"	f
+download_ckpt	yolov6/utils/general.py	/^def download_ckpt(path):$/;"	f
+draw	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^int Yolo::draw(cv::Mat& rgb, const std::vector<Object>& objects)$/;"	f	class:Yolo
+draw_fps	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^static int draw_fps(cv::Mat& rgb)$/;"	f	file:
+draw_label	deploy/ONNX/OpenCV/yolo.py	/^def draw_label(input_image, label, left, top):$/;"	f
+draw_label	deploy/ONNX/OpenCV/yolo_video.py	/^def draw_label(im, label, x, y):$/;"	f
+draw_label	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^void draw_label(Mat& input_image, string label, int left, int top)$/;"	f
+draw_label	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^void draw_label(Mat& input_image, string label, int left, int top)$/;"	f
+draw_objects	deploy/TensorRT/yolov6.cpp	/^static void draw_objects(const cv::Mat& bgr, const std::vector<Object>& objects, std::string f)$/;"	f	file:
+draw_text	yolov6/core/inferer.py	/^    def draw_text($/;"	m	class:Inferer
+draw_unsupported	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^static int draw_unsupported(cv::Mat& rgb)$/;"	f	file:
+dynamic_axes	deploy/ONNX/export_onnx.py	/^                              dynamic_axes=dynamic_axes)$/;"	v
+dynamic_axes	deploy/ONNX/export_onnx.py	/^        dynamic_axes = {$/;"	v
+dynamic_axes	deploy/ONNX/export_onnx.py	/^    dynamic_axes = None$/;"	v
+dynamic_axes	tools/partial_quantization/partial_quant.py	/^                          dynamic_axes=dynamic_axes$/;"	v
+dynamic_axes	tools/partial_quantization/partial_quant.py	/^        dynamic_axes = {"image_arrays": {0: "batch"}, "outputs": {0: "batch"}}$/;"	v
+dynamic_axes	tools/qat/qat_export.py	/^                          dynamic_axes=dynamic_axes$/;"	v
+dynamic_axes	tools/qat/qat_export.py	/^        dynamic_axes = {$/;"	v
+end	deploy/NCNN/Android/gradlew.bat	/^:end$/;"	l
+eval	tools/partial_quantization/eval.py	/^    def eval(self, model):$/;"	m	class:EvalerWrapper
+eval_model	yolov6/core/engine.py	/^    def eval_model(self):$/;"	m	class:Trainer
+eval_model	yolov6/core/evaler.py	/^    def eval_model(self, pred_results, model, dataloader, task):$/;"	m	class:Evaler
+eval_params	configs/experiment/eval_640_repro.py	/^eval_params = dict($/;"	v
+eval_params	configs/experiment/yolov6n_with_eval_params.py	/^eval_params = dict($/;"	v
+eval_speed	yolov6/core/evaler.py	/^    def eval_speed(self, task):$/;"	m	class:Evaler
+eval_trt	yolov6/core/evaler.py	/^    def eval_trt(self, engine, stride=32):$/;"	m	class:Evaler
+execute	deploy/NCNN/Android/gradlew.bat	/^:execute$/;"	l
+executor	tools/quantization/ppq/ProgramEntrance.py	/^executor = TorchExecutor(graph=graph, device='cuda')$/;"	v
+export	yolov6/models/effidehead.py	/^    export = False$/;"	v	class:Detect
+export	yolov6/models/heads/effidehead_distill_ns.py	/^    export = False$/;"	v	class:Detect
+export	yolov6/models/heads/effidehead_fuseab.py	/^    export = False$/;"	v	class:Detect
+export	yolov6/models/heads/effidehead_lite.py	/^    export = False$/;"	v	class:Detect
+export	yolov6/models/yolo.py	/^    export = False$/;"	v	class:Model
+export	yolov6/models/yolo_lite.py	/^    export = False$/;"	v	class:Model
+export_dir	deploy/OpenVINO/export_openvino.py	/^        export_dir = str(import_file).replace('.onnx', '_openvino')$/;"	v
+export_file	deploy/NCNN/export_torchscript.py	/^        export_file = args.weights.replace('.pt', '.torchscript')  # filename$/;"	v
+export_file	deploy/ONNX/export_onnx.py	/^        export_file = args.weights.replace('.pt', '.onnx')  # filename$/;"	v
+export_file	deploy/OpenVINO/export_openvino.py	/^        export_file = args.weights.replace('.pt', '.onnx')  # filename$/;"	v
+export_file	tools/partial_quantization/partial_quant.py	/^        export_file = args.weights.replace('.pt', '_partial_bs{}.onnx'.format(args.export_batch_size))  # filename$/;"	v
+export_file	tools/partial_quantization/partial_quant.py	/^        export_file = args.weights.replace('.pt', '_partial_dynamic.onnx')  # filename$/;"	v
+export_file	tools/qat/qat_export.py	/^            export_file = export_file.replace('.onnx', '_e2e.onnx')$/;"	v
+export_file	tools/qat/qat_export.py	/^            export_file = export_file.replace('.onnx', '_graph_opt.onnx')$/;"	v
+export_file	tools/qat/qat_export.py	/^        export_file = args.quant_weights.replace('.pt', '_bs{}.onnx'.format(args.export_batch_size))  # filename$/;"	v
+export_file	tools/qat/qat_export.py	/^        export_file = args.quant_weights.replace('.pt', '_dynamic.onnx')  # filename$/;"	v
+exporter	tools/quantization/ppq/ProgramEntrance.py	/^exporter = PFL.Exporter(platform=TargetPlatform.TRT_INT8)$/;"	v
+extract_blocks_into_list	yolov6/utils/RepOptimizer.py	/^def extract_blocks_into_list(model, blocks):$/;"	f
+extract_scales	yolov6/utils/RepOptimizer.py	/^def extract_scales(model):$/;"	f
+facing	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private int facing = 0;$/;"	f	class:MainActivity	file:
+fail	deploy/NCNN/Android/gradlew.bat	/^:fail$/;"	l
+fast_exp	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static float fast_exp(float x)$/;"	f	file:
+filename	yolov6/utils/config.py	/^    def filename(self):$/;"	m	class:Config
+filename2imgid	yolov6/utils/general.py	/^def filename2imgid(anno_path):$/;"	f
+findJavaFromJavaHome	deploy/NCNN/Android/gradlew.bat	/^:findJavaFromJavaHome$/;"	l
+find_latest_checkpoint	yolov6/utils/general.py	/^def find_latest_checkpoint(search_dir='.'):$/;"	f
+fliplr	configs/base/yolov6l_base.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6l_base_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6m_base.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6m_base_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6n_base.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6n_base_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6s_base.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/base/yolov6s_base_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/experiment/yolov6n_with_eval_params.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/experiment/yolov6s_csp_scaled.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/experiment/yolov6t.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/experiment/yolov6t_csp_scaled.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/experiment/yolov6t_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6l_mbla.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6l_mbla_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6m_mbla.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6m_mbla_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6s_mbla.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6s_mbla_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6x_mbla.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/mbla/yolov6x_mbla_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/qarepvgg/yolov6m_qa.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/qarepvgg/yolov6n_qa.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/qarepvgg/yolov6s_qa.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6_tiny_hs.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6_tiny_opt.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6_tiny_opt_qat.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6n_hs.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6n_opt.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6n_opt_qat.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6s_hs.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6s_opt.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/repopt/yolov6s_opt_qat.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6_lite/yolov6_lite_l.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6_lite/yolov6_lite_m.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6_lite/yolov6_lite_s.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6l.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6l6.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6l6_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6l_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6m.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6m6.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6m6_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6m_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6n.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6n6.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6n6_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6n_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6s.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6s6.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6s6_finetune.py	/^    fliplr=0.5,$/;"	v
+fliplr	configs/yolov6s_finetune.py	/^    fliplr=0.5,$/;"	v
+flipud	configs/base/yolov6l_base.py	/^    flipud=0.0,$/;"	v
+flipud	configs/base/yolov6l_base_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/base/yolov6m_base.py	/^    flipud=0.0,$/;"	v
+flipud	configs/base/yolov6m_base_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/base/yolov6n_base.py	/^    flipud=0.0,$/;"	v
+flipud	configs/base/yolov6n_base_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/base/yolov6s_base.py	/^    flipud=0.0,$/;"	v
+flipud	configs/base/yolov6s_base_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/experiment/yolov6n_with_eval_params.py	/^    flipud=0.0,$/;"	v
+flipud	configs/experiment/yolov6s_csp_scaled.py	/^    flipud=0.0,$/;"	v
+flipud	configs/experiment/yolov6t.py	/^    flipud=0.0,$/;"	v
+flipud	configs/experiment/yolov6t_csp_scaled.py	/^    flipud=0.0,$/;"	v
+flipud	configs/experiment/yolov6t_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/mbla/yolov6l_mbla.py	/^    flipud=0.0,$/;"	v
+flipud	configs/mbla/yolov6l_mbla_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/mbla/yolov6m_mbla.py	/^    flipud=0.0,$/;"	v
+flipud	configs/mbla/yolov6m_mbla_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/mbla/yolov6s_mbla.py	/^    flipud=0.0,$/;"	v
+flipud	configs/mbla/yolov6s_mbla_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/mbla/yolov6x_mbla.py	/^    flipud=0.0,$/;"	v
+flipud	configs/mbla/yolov6x_mbla_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/qarepvgg/yolov6m_qa.py	/^    flipud=0.0,$/;"	v
+flipud	configs/qarepvgg/yolov6n_qa.py	/^    flipud=0.0,$/;"	v
+flipud	configs/qarepvgg/yolov6s_qa.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6_tiny_hs.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6_tiny_opt.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6_tiny_opt_qat.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6n_hs.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6n_opt.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6n_opt_qat.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6s_hs.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6s_opt.py	/^    flipud=0.0,$/;"	v
+flipud	configs/repopt/yolov6s_opt_qat.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6_lite/yolov6_lite_l.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6_lite/yolov6_lite_m.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6_lite/yolov6_lite_s.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6l.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6l6.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6l6_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6l_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6m.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6m6.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6m6_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6m_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6n.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6n6.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6n6_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6n_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6s.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6s6.py	/^    flipud=0.0,$/;"	v
+flipud	configs/yolov6s6_finetune.py	/^    flipud=0.00856,$/;"	v
+flipud	configs/yolov6s_finetune.py	/^    flipud=0.00856,$/;"	v
+font_check	yolov6/core/inferer.py	/^    def font_check(font='.\/yolov6\/utils\/Arial.ttf', size=10):$/;"	m	class:Inferer
+format	tools/quantization/tensorrt/post_training/Calibrator.py	/^                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",$/;"	v
+format	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",$/;"	v
+forward	hubconf.py	/^    def forward(self, x, src_shape):$/;"	m	class:Detector
+forward	yolov6/assigners/atss_assigner.py	/^    def forward(self,$/;"	m	class:ATSSAssigner
+forward	yolov6/assigners/tal_assigner.py	/^    def forward(self,$/;"	m	class:TaskAlignedAssigner
+forward	yolov6/layers/common.py	/^    def forward(self, im, val=False):$/;"	m	class:DetectBackend
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:LinearAddBlock
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:Lite_EffiBlockS1
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:Lite_EffiBlockS2
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:QARepVGGBlock
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:QARepVGGBlockV2
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:RealVGGBlock
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:RepVGGBlock
+forward	yolov6/layers/common.py	/^    def forward(self, inputs):$/;"	m	class:ScaleLayer
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:BepC3
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:BiFusion
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:BottleRep
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:BottleRep3
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:CSPBlock
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:CSPSPPF
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:CSPSPPFModule
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:ConvBN
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:ConvBNHS
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:ConvBNReLU
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:ConvBNSiLU
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:ConvModule
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:DPBlock
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:DarknetBlock
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:MBLABlock
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:RepBlock
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:SEBlock
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:SPPF
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:SPPFModule
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:SimCSPSPPF
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:SimSPPF
+forward	yolov6/layers/common.py	/^    def forward(self, x):$/;"	m	class:Transpose
+forward	yolov6/layers/common.py	/^    def forward(x):$/;"	m	class:SiLU
+forward	yolov6/models/efficientrep.py	/^    def forward(self, x):$/;"	m	class:CSPBepBackbone
+forward	yolov6/models/efficientrep.py	/^    def forward(self, x):$/;"	m	class:CSPBepBackbone_P6
+forward	yolov6/models/efficientrep.py	/^    def forward(self, x):$/;"	m	class:EfficientRep
+forward	yolov6/models/efficientrep.py	/^    def forward(self, x):$/;"	m	class:EfficientRep6
+forward	yolov6/models/efficientrep.py	/^    def forward(self, x):$/;"	m	class:Lite_EffiBackbone
+forward	yolov6/models/effidehead.py	/^    def forward(self, x):$/;"	m	class:Detect
+forward	yolov6/models/end2end.py	/^    def forward($/;"	m	class:TRT7_NMS
+forward	yolov6/models/end2end.py	/^    def forward($/;"	m	class:TRT8_NMS
+forward	yolov6/models/end2end.py	/^    def forward(ctx,$/;"	m	class:ORT_NMS
+forward	yolov6/models/end2end.py	/^    def forward(self, x):$/;"	m	class:End2End
+forward	yolov6/models/end2end.py	/^    def forward(self, x):$/;"	m	class:ONNX_ORT
+forward	yolov6/models/end2end.py	/^    def forward(self, x):$/;"	m	class:ONNX_TRT7
+forward	yolov6/models/end2end.py	/^    def forward(self, x):$/;"	m	class:ONNX_TRT8
+forward	yolov6/models/heads/effidehead_distill_ns.py	/^    def forward(self, x):$/;"	m	class:Detect
+forward	yolov6/models/heads/effidehead_fuseab.py	/^    def forward(self, x):$/;"	m	class:Detect
+forward	yolov6/models/heads/effidehead_lite.py	/^    def forward(self, x):$/;"	m	class:Detect
+forward	yolov6/models/losses/loss.py	/^    def forward(self, pred_dist, pred_bboxes, anchor_points,$/;"	m	class:BboxLoss
+forward	yolov6/models/losses/loss.py	/^    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):$/;"	m	class:VarifocalLoss
+forward	yolov6/models/losses/loss_distill.py	/^    def forward(self, pred_dist, pred_bboxes, t_pred_dist, t_pred_bboxes, temperature, anchor_points,$/;"	m	class:BboxLoss
+forward	yolov6/models/losses/loss_distill.py	/^    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):$/;"	m	class:VarifocalLoss
+forward	yolov6/models/losses/loss_distill_ns.py	/^    def forward(self, pred_dist, pred_bboxes_lrtb, pred_bboxes, t_pred_dist, t_pred_bboxes, temperature, anchor_points,$/;"	m	class:BboxLoss
+forward	yolov6/models/losses/loss_distill_ns.py	/^    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):$/;"	m	class:VarifocalLoss
+forward	yolov6/models/losses/loss_fuseab.py	/^    def forward(self, pred_dist, pred_bboxes, anchor_points,$/;"	m	class:BboxLoss
+forward	yolov6/models/losses/loss_fuseab.py	/^    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):$/;"	m	class:VarifocalLoss
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:CSPRepBiFPANNeck
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:CSPRepBiFPANNeck_P6
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:CSPRepPANNeck
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:CSPRepPANNeck_P6
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:Lite_EffiNeck
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:RepBiFPANNeck
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:RepBiFPANNeck6
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:RepPANNeck
+forward	yolov6/models/reppan.py	/^    def forward(self, input):$/;"	m	class:RepPANNeck6
+forward	yolov6/models/yolo.py	/^    def forward(self, x):$/;"	m	class:Model
+forward	yolov6/models/yolo_lite.py	/^    def forward(self, x):$/;"	m	class:Model
+forward_fuse	yolov6/layers/common.py	/^    def forward_fuse(self, x):$/;"	m	class:ConvModule
+forward_fuse	yolov6/layers/common.py	/^    def forward_fuse(self, x):$/;"	m	class:DPBlock
+fp16_clamp	yolov6/assigners/iou2d_calculator.py	/^def fp16_clamp(x, min=None, max=None):$/;"	f
+frame	deploy/ONNX/OpenCV/yolo.py	/^	frame = cv2.imread(img_path)$/;"	v
+fromfile	yolov6/utils/config.py	/^    def fromfile(filename):$/;"	m	class:Config
+fuse_P2	configs/base/yolov6l_base.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6l_base_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6m_base.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6m_base_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6n_base.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6n_base_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6s_base.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/base/yolov6s_base_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6l_mbla.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6l_mbla_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6m_mbla.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6m_mbla_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6s_mbla.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6s_mbla_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6x_mbla.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/mbla/yolov6x_mbla_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/qarepvgg/yolov6m_qa.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/qarepvgg/yolov6n_qa.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/qarepvgg/yolov6s_qa.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6l.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6l6.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6l6_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6l_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6m.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6m6.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6m6_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6m_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6n.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6n6.py	/^        fuse_P2=True, # if use RepBiFPANNeck6, please set fuse_P2 to True.$/;"	v
+fuse_P2	configs/yolov6n6_finetune.py	/^        fuse_P2=True, # if use RepBiFPANNeck6, please set fuse_P2 to True.$/;"	v
+fuse_P2	configs/yolov6n_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6s.py	/^        fuse_P2=True,$/;"	v
+fuse_P2	configs/yolov6s6.py	/^        fuse_P2=True, # if use RepBiFPANNeck6, please set fuse_P2 to True.$/;"	v
+fuse_P2	configs/yolov6s6_finetune.py	/^        fuse_P2=True, # if use RepBiFPANNeck6, please set fuse_P2 to True.$/;"	v
+fuse_P2	configs/yolov6s_finetune.py	/^        fuse_P2=True,$/;"	v
+fuse_conv_and_bn	yolov6/utils/torch_utils.py	/^def fuse_conv_and_bn(conv, bn):$/;"	f
+fuse_model	yolov6/utils/torch_utils.py	/^def fuse_model(model):$/;"	f
+gLogger	deploy/TensorRT/yolov6.cpp	/^static Logger gLogger;$/;"	v	file:
+g_camera	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^static MyNdkCamera* g_camera = 0;$/;"	v	file:
+g_yolo	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^static Yolo* g_yolo = 0;$/;"	v	file:
+genCmdlineString	deploy/TensorRT/logging.h	/^    static std::string genCmdlineString(int argc, char const* const* argv)$/;"	f	class:Logger
+gen_voc07_12	yolov6/data/voc2yolo.py	/^def gen_voc07_12(voc_path):$/;"	f
+general_augment	yolov6/data/datasets.py	/^    def general_augment(self, img, labels):$/;"	m	class:TrainValDataset
+generate_anchors	yolov6/assigners/anchor_generator.py	/^def generate_anchors(feats, fpn_strides, grid_cell_size=5.0, grid_cell_offset=0.5,  device='cpu', is_eval=False, mode='af'):$/;"	f
+generate_coco_format_labels	yolov6/data/datasets.py	/^    def generate_coco_format_labels(img_info, class_names, save_path):$/;"	m	class:TrainValDataset
+generate_colors	yolov6/core/inferer.py	/^    def generate_colors(i, bgr=False):$/;"	m	class:Inferer
+generate_gradient_masks	yolov6/utils/RepOptimizer.py	/^    def generate_gradient_masks(self, scales_by_idx, conv3x3_by_idx, cpu_mode=False):$/;"	m	class:RepVGGOptimizer
+generate_proposals	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static void generate_proposals(int stride, const ncnn::Mat& pred, float prob_threshold, std::vector<Object>& objects)$/;"	f	file:
+generate_results	deploy/TensorRT/eval_yolo_trt.py	/^def generate_results(data_class,$/;"	f
+generate_results	deploy/TensorRT/visualize.py	/^def generate_results(processor, imgs_dir, visual_dir, jpgs, conf_thres, iou_thres,$/;"	f
+generate_yolo_proposals	deploy/TensorRT/yolov6.cpp	/^static void generate_yolo_proposals(float* feat_blob, int output_size, float prob_threshold, std::vector<Object>& objects)$/;"	f	file:
+getReportableSeverity	deploy/TensorRT/logging.h	/^    Severity getReportableSeverity() const$/;"	f	class:Logger
+getTRTLogger	deploy/TensorRT/logging.h	/^    nvinfer1::ILogger& getTRTLogger()$/;"	f	class:Logger
+get_args_parser	deploy/ONNX/eval_trt.py	/^def get_args_parser(add_help=True):$/;"	f
+get_args_parser	tools/eval.py	/^def get_args_parser(add_help=True):$/;"	f
+get_args_parser	tools/infer.py	/^def get_args_parser(add_help=True):$/;"	f
+get_args_parser	tools/train.py	/^def get_args_parser(add_help=True):$/;"	f
+get_batch	deploy/TensorRT/calibrator.py	/^    def get_batch(self, names):$/;"	m	class:Calibrator
+get_batch	tools/quantization/tensorrt/post_training/Calibrator.py	/^    def get_batch(self, names):$/;"	m	class:ImageCalibrator
+get_batch_size	deploy/TensorRT/calibrator.py	/^    def get_batch_size(self):$/;"	m	class:Calibrator
+get_batch_size	tools/quantization/tensorrt/post_training/Calibrator.py	/^    def get_batch_size(self):$/;"	m	class:ImageCalibrator
+get_batch_sizes	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^def get_batch_sizes(max_batch_size):$/;"	f
+get_block	yolov6/layers/common.py	/^def get_block(mode):$/;"	f
+get_box_metrics	yolov6/assigners/tal_assigner.py	/^    def get_box_metrics(self,$/;"	m	class:TaskAlignedAssigner
+get_calibration_files	tools/quantization/tensorrt/post_training/Calibrator.py	/^def get_calibration_files(calibration_data, max_calibration_size=None, allowed_extensions=(".jpeg", ".jpg", ".png")):$/;"	f
+get_cfg_value	yolov6/core/engine.py	/^            def get_cfg_value(cfg_dict, value_str, default_value):$/;"	f	function:Trainer.eval_model
+get_conv_qdq_node	tools/qat/onnx_utils.py	/^def get_conv_qdq_node(nodes, conv_node):$/;"	f
+get_data_loader	yolov6/core/engine.py	/^    def get_data_loader(args, cfg, data_dict):$/;"	m	class:Trainer
+get_envs	yolov6/utils/envs.py	/^def get_envs():$/;"	f
+get_equivalent_kernel_bias	yolov6/layers/common.py	/^    def get_equivalent_kernel_bias(self):$/;"	m	class:QARepVGGBlock
+get_equivalent_kernel_bias	yolov6/layers/common.py	/^    def get_equivalent_kernel_bias(self):$/;"	m	class:QARepVGGBlockV2
+get_equivalent_kernel_bias	yolov6/layers/common.py	/^    def get_equivalent_kernel_bias(self):$/;"	m	class:RepVGGBlock
+get_hash	yolov6/data/datasets.py	/^    def get_hash(paths):$/;"	m	class:TrainValDataset
+get_imgs_labels	yolov6/data/datasets.py	/^    def get_imgs_labels(self, img_dirs):$/;"	m	class:TrainValDataset
+get_input_shape	deploy/TensorRT/Processor.py	/^def get_input_shape(engine):$/;"	f
+get_input_shape	deploy/TensorRT/tensorrt_processor.py	/^def get_input_shape(engine):$/;"	f
+get_int8_calibrator	tools/quantization/tensorrt/post_training/Calibrator.py	/^def get_int8_calibrator(calib_cache, calib_data, max_calib_size, calib_batch_size):$/;"	f
+get_lr_scheduler	yolov6/core/engine.py	/^    def get_lr_scheduler(args, cfg, optimizer):$/;"	m	class:Trainer
+get_max_class	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^int yolox::get_max_class(float* scores)$/;"	f	class:yolox
+get_model	yolov6/core/engine.py	/^    def get_model(self, args, cfg, nc, device):$/;"	m	class:Trainer
+get_model_info	yolov6/utils/torch_utils.py	/^def get_model_info(model, img_size=640):$/;"	f
+get_module	tools/partial_quantization/utils.py	/^def get_module(model, submodule_key):$/;"	f
+get_mosaic	yolov6/data/datasets.py	/^    def get_mosaic(self, index, shape):$/;"	m	class:TrainValDataset
+get_next_node	tools/qat/onnx_utils.py	/^def get_next_node(nodes, node):$/;"	f
+get_optimizer	yolov6/core/engine.py	/^    def get_optimizer(self, args, cfg, model):$/;"	m	class:Trainer
+get_optimizer_param	yolov6/utils/RepOptimizer.py	/^def get_optimizer_param(args, cfg, model):$/;"	f
+get_pos_mask	yolov6/assigners/tal_assigner.py	/^    def get_pos_mask(self,$/;"	m	class:TaskAlignedAssigner
+get_prev_node	tools/qat/onnx_utils.py	/^def get_prev_node(nodes, node):$/;"	f
+get_remove_qdq_onnx_and_cache	tools/qat/onnx_utils.py	/^def get_remove_qdq_onnx_and_cache(onnx_file):$/;"	f
+get_targets	yolov6/assigners/atss_assigner.py	/^    def get_targets(self,$/;"	m	class:ATSSAssigner
+get_targets	yolov6/assigners/tal_assigner.py	/^    def get_targets(self,$/;"	m	class:TaskAlignedAssigner
+get_teacher_model	yolov6/core/engine.py	/^    def get_teacher_model(self, args, cfg, nc, device):$/;"	m	class:Trainer
+get_transform_matrix	yolov6/data/data_augment.py	/^def get_transform_matrix(img_shape, new_shape, degrees, scale, shear, translate):$/;"	f
+graph	tools/quantization/ppq/ProgramEntrance.py	/^graph = load_onnx_graph(onnx_import_file='Models\/det_model\/yolov6s.onnx')$/;"	v
+head	configs/base/yolov6l_base.py	/^    head=dict($/;"	v
+head	configs/base/yolov6l_base_finetune.py	/^    head=dict($/;"	v
+head	configs/base/yolov6m_base.py	/^    head=dict($/;"	v
+head	configs/base/yolov6m_base_finetune.py	/^    head=dict($/;"	v
+head	configs/base/yolov6n_base.py	/^    head=dict($/;"	v
+head	configs/base/yolov6n_base_finetune.py	/^    head=dict($/;"	v
+head	configs/base/yolov6s_base.py	/^    head=dict($/;"	v
+head	configs/base/yolov6s_base_finetune.py	/^    head=dict($/;"	v
+head	configs/experiment/yolov6n_with_eval_params.py	/^    head=dict($/;"	v
+head	configs/experiment/yolov6s_csp_scaled.py	/^    head=dict($/;"	v
+head	configs/experiment/yolov6t.py	/^    head=dict($/;"	v
+head	configs/experiment/yolov6t_csp_scaled.py	/^    head=dict($/;"	v
+head	configs/experiment/yolov6t_finetune.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6l_mbla.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6l_mbla_finetune.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6m_mbla.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6m_mbla_finetune.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6s_mbla.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6s_mbla_finetune.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6x_mbla.py	/^    head=dict($/;"	v
+head	configs/mbla/yolov6x_mbla_finetune.py	/^    head=dict($/;"	v
+head	configs/qarepvgg/yolov6m_qa.py	/^    head=dict($/;"	v
+head	configs/qarepvgg/yolov6n_qa.py	/^    head=dict($/;"	v
+head	configs/qarepvgg/yolov6s_qa.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6_tiny_hs.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6_tiny_opt.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6_tiny_opt_qat.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6n_hs.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6n_opt.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6n_opt_qat.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6s_hs.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6s_opt.py	/^    head=dict($/;"	v
+head	configs/repopt/yolov6s_opt_qat.py	/^    head=dict($/;"	v
+head	configs/yolov6_lite/yolov6_lite_l.py	/^    head=dict($/;"	v
+head	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6_lite/yolov6_lite_m.py	/^    head=dict($/;"	v
+head	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6_lite/yolov6_lite_s.py	/^    head=dict($/;"	v
+head	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6l.py	/^    head=dict($/;"	v
+head	configs/yolov6l6.py	/^    head=dict($/;"	v
+head	configs/yolov6l6_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6l_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6m.py	/^    head=dict($/;"	v
+head	configs/yolov6m6.py	/^    head=dict($/;"	v
+head	configs/yolov6m6_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6m_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6n.py	/^    head=dict($/;"	v
+head	configs/yolov6n6.py	/^    head=dict($/;"	v
+head	configs/yolov6n6_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6n_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6s.py	/^    head=dict($/;"	v
+head	configs/yolov6s6.py	/^    head=dict($/;"	v
+head	configs/yolov6s6_finetune.py	/^    head=dict($/;"	v
+head	configs/yolov6s_finetune.py	/^    head=dict($/;"	v
+histogram_amax_method	configs/repopt/yolov6_tiny_opt_qat.py	/^    histogram_amax_method='entropy',$/;"	v
+histogram_amax_method	configs/repopt/yolov6n_opt_qat.py	/^    histogram_amax_method='entropy',$/;"	v
+histogram_amax_method	configs/repopt/yolov6s_opt_qat.py	/^    histogram_amax_method='entropy',$/;"	v
+histogram_amax_percentile	configs/repopt/yolov6_tiny_opt_qat.py	/^    histogram_amax_percentile=99.99,$/;"	v
+histogram_amax_percentile	configs/repopt/yolov6n_opt_qat.py	/^    histogram_amax_percentile=99.99,$/;"	v
+histogram_amax_percentile	configs/repopt/yolov6s_opt_qat.py	/^    histogram_amax_percentile=99.99,$/;"	v
+hsv_h	configs/base/yolov6l_base.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/base/yolov6l_base_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/base/yolov6m_base.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/base/yolov6m_base_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/base/yolov6n_base.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/base/yolov6n_base_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/base/yolov6s_base.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/base/yolov6s_base_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/experiment/yolov6n_with_eval_params.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/experiment/yolov6s_csp_scaled.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/experiment/yolov6t.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/experiment/yolov6t_csp_scaled.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/experiment/yolov6t_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/mbla/yolov6l_mbla.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/mbla/yolov6l_mbla_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/mbla/yolov6m_mbla.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/mbla/yolov6m_mbla_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/mbla/yolov6s_mbla.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/mbla/yolov6s_mbla_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/mbla/yolov6x_mbla.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/mbla/yolov6x_mbla_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/qarepvgg/yolov6m_qa.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/qarepvgg/yolov6n_qa.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/qarepvgg/yolov6s_qa.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6_tiny_hs.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6_tiny_opt.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6_tiny_opt_qat.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6n_hs.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6n_opt.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6n_opt_qat.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6s_hs.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6s_opt.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/repopt/yolov6s_opt_qat.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6_lite/yolov6_lite_l.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6_lite/yolov6_lite_m.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6_lite/yolov6_lite_s.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6l.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6l6.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6l6_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6l_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6m.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6m6.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6m6_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6m_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6n.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6n6.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6n6_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6n_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6s.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6s6.py	/^    hsv_h=0.015,$/;"	v
+hsv_h	configs/yolov6s6_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_h	configs/yolov6s_finetune.py	/^    hsv_h=0.0138,$/;"	v
+hsv_s	configs/base/yolov6l_base.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/base/yolov6l_base_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/base/yolov6m_base.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/base/yolov6m_base_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/base/yolov6n_base.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/base/yolov6n_base_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/base/yolov6s_base.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/base/yolov6s_base_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/experiment/yolov6n_with_eval_params.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/experiment/yolov6s_csp_scaled.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/experiment/yolov6t.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/experiment/yolov6t_csp_scaled.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/experiment/yolov6t_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/mbla/yolov6l_mbla.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/mbla/yolov6l_mbla_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/mbla/yolov6m_mbla.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/mbla/yolov6m_mbla_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/mbla/yolov6s_mbla.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/mbla/yolov6s_mbla_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/mbla/yolov6x_mbla.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/mbla/yolov6x_mbla_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/qarepvgg/yolov6m_qa.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/qarepvgg/yolov6n_qa.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/qarepvgg/yolov6s_qa.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6_tiny_hs.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6_tiny_opt.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6_tiny_opt_qat.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6n_hs.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6n_opt.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6n_opt_qat.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6s_hs.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6s_opt.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/repopt/yolov6s_opt_qat.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6_lite/yolov6_lite_l.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6_lite/yolov6_lite_m.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6_lite/yolov6_lite_s.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6l.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6l6.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6l6_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6l_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6m.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6m6.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6m6_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6m_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6n.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6n6.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6n6_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6n_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6s.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6s6.py	/^    hsv_s=0.7,$/;"	v
+hsv_s	configs/yolov6s6_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_s	configs/yolov6s_finetune.py	/^    hsv_s=0.664,$/;"	v
+hsv_v	configs/base/yolov6l_base.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/base/yolov6l_base_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/base/yolov6m_base.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/base/yolov6m_base_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/base/yolov6n_base.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/base/yolov6n_base_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/base/yolov6s_base.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/base/yolov6s_base_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/experiment/yolov6n_with_eval_params.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/experiment/yolov6s_csp_scaled.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/experiment/yolov6t.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/experiment/yolov6t_csp_scaled.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/experiment/yolov6t_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/mbla/yolov6l_mbla.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/mbla/yolov6l_mbla_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/mbla/yolov6m_mbla.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/mbla/yolov6m_mbla_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/mbla/yolov6s_mbla.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/mbla/yolov6s_mbla_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/mbla/yolov6x_mbla.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/mbla/yolov6x_mbla_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/qarepvgg/yolov6m_qa.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/qarepvgg/yolov6n_qa.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/qarepvgg/yolov6s_qa.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6_tiny_hs.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6_tiny_opt.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6_tiny_opt_qat.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6n_hs.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6n_opt.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6n_opt_qat.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6s_hs.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6s_opt.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/repopt/yolov6s_opt_qat.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6_lite/yolov6_lite_l.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6_lite/yolov6_lite_m.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6_lite/yolov6_lite_s.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6l.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6l6.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6l6_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6l_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6m.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6m6.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6m6_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6m_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6n.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6n6.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6n6_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6n_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6s.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6s6.py	/^    hsv_v=0.4,$/;"	v
+hsv_v	configs/yolov6s6_finetune.py	/^    hsv_v=0.464,$/;"	v
+hsv_v	configs/yolov6s_finetune.py	/^    hsv_v=0.464,$/;"	v
+hyp	tools/partial_quantization/sensitivity_analyse.py	/^        hyp=dict(cfg.data_aug),$/;"	v
+image_reader	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    AImageReader* image_reader;$/;"	m	class:NdkCamera
+image_reader_surface	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ANativeWindow* image_reader_surface;$/;"	m	class:NdkCamera
+image_reader_target	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ACameraOutputTarget* image_reader_target;$/;"	m	class:NdkCamera
+img	deploy/NCNN/export_torchscript.py	/^    img = torch.zeros(args.batch_size, 3, *args.img_size).to(device)  # image size(1,3,320,192) iDetection$/;"	v
+img	deploy/ONNX/OpenCV/yolo.py	/^		img = post_process(frame.copy(), detections)$/;"	v
+img	deploy/ONNX/export_onnx.py	/^    img = torch.zeros(args.batch_size, 3, *args.img_size).to(device)  # image size(1,3,320,192) iDetection$/;"	v
+img	deploy/OpenVINO/export_openvino.py	/^    img = torch.zeros(args.batch_size, 3, *args.img_size).to(device)  # image size(1,3,320,192) iDetection$/;"	v
+img	tools/partial_quantization/partial_quant.py	/^        img = torch.zeros(1, 3, *args.img_size).to(device)$/;"	v
+img	tools/partial_quantization/partial_quant.py	/^        img = torch.zeros(args.export_batch_size, 3, *args.img_size).to(device)$/;"	v
+img	tools/qat/qat_export.py	/^        img = torch.zeros(1, 3, *args.img_size).to(device)$/;"	v
+img	tools/qat/qat_export.py	/^        img = torch.zeros(args.export_batch_size, 3, *args.img_size).to(device)$/;"	v
+img2label_paths	yolov6/data/datasets.py	/^def img2label_paths(img_paths):$/;"	f
+img_size	configs/experiment/eval_640_repro.py	/^        img_size=1280,$/;"	v
+img_size	configs/experiment/eval_640_repro.py	/^        img_size=640,$/;"	v
+img_size	configs/experiment/yolov6n_with_eval_params.py	/^    img_size=None,  #None mean will be the same as train image size$/;"	v
+img_size	tools/partial_quantization/sensitivity_analyse.py	/^        img_size=args.img_size[0],$/;"	v
+import_file	deploy/OpenVINO/export_openvino.py	/^        import_file = args.weights.replace('.pt', '.onnx')$/;"	v
+in_channels	configs/base/yolov6l_base.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6l_base_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6m_base.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6m_base_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6n_base.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6n_base_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6s_base.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/base/yolov6s_base_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/experiment/yolov6n_with_eval_params.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/experiment/yolov6s_csp_scaled.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/experiment/yolov6t.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/experiment/yolov6t_csp_scaled.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/experiment/yolov6t_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6l_mbla.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6l_mbla_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6m_mbla.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6m_mbla_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6s_mbla.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6s_mbla_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6x_mbla.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/mbla/yolov6x_mbla_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/qarepvgg/yolov6m_qa.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/qarepvgg/yolov6n_qa.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/qarepvgg/yolov6s_qa.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6_tiny_hs.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6_tiny_opt.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6_tiny_opt_qat.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6n_hs.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6n_opt.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6n_opt_qat.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6s_hs.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6s_opt.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/repopt/yolov6s_opt_qat.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_l.py	/^        in_channels=[256, 128, 64],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_l.py	/^        in_channels=[96, 96, 96, 96],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        in_channels=[256, 128, 64],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        in_channels=[96, 96, 96, 96],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_m.py	/^        in_channels=[256, 128, 64],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_m.py	/^        in_channels=[96, 96, 96, 96],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        in_channels=[256, 128, 64],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        in_channels=[96, 96, 96, 96],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_s.py	/^        in_channels=[256, 128, 64],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_s.py	/^        in_channels=[96, 96, 96, 96],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        in_channels=[256, 128, 64],$/;"	v
+in_channels	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        in_channels=[96, 96, 96, 96],$/;"	v
+in_channels	configs/yolov6l.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6l6.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6l6_finetune.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6l_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6m.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6m6.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6m6_finetune.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6m_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6n.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6n6.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6n6_finetune.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6n_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6s.py	/^        in_channels=[128, 256, 512],$/;"	v
+in_channels	configs/yolov6s6.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6s6_finetune.py	/^        in_channels=[128, 256, 512, 1024],$/;"	v
+in_channels	configs/yolov6s_finetune.py	/^        in_channels=[128, 256, 512],$/;"	v
+increment_name	yolov6/utils/general.py	/^def increment_name(path):$/;"	f
+infer	yolov6/core/inferer.py	/^    def infer(self, conf_thres, iou_thres, classes, agnostic_nms, max_det, save_dir, save_txt, save_img, hide_labels, hide_conf, view_img=True):$/;"	m	class:Inferer
+infer_on_rect	configs/experiment/eval_640_repro.py	/^        infer_on_rect=False,$/;"	v
+infer_on_rect	configs/experiment/yolov6n_with_eval_params.py	/^    infer_on_rect=True,$/;"	v
+inference	deploy/TensorRT/Processor.py	/^    def inference(self, inputs):$/;"	m	class:Processor
+inference	deploy/TensorRT/tensorrt_processor.py	/^    def inference(self, inputs):$/;"	m	class:Processor
+init_data	yolov6/core/evaler.py	/^        def init_data(dataloader, task):$/;"	f	function:Evaler.eval_trt
+init_data	yolov6/core/evaler.py	/^    def init_data(self, dataloader, task):$/;"	m	class:Evaler
+init_engine	yolov6/core/evaler.py	/^        def init_engine(engine):$/;"	f	function:Evaler.eval_trt
+init_model	yolov6/core/evaler.py	/^    def init_model(self, model, weights, task):$/;"	m	class:Evaler
+initialize_biases	yolov6/models/effidehead.py	/^    def initialize_biases(self):$/;"	m	class:Detect
+initialize_biases	yolov6/models/heads/effidehead_distill_ns.py	/^    def initialize_biases(self):$/;"	m	class:Detect
+initialize_biases	yolov6/models/heads/effidehead_fuseab.py	/^    def initialize_biases(self):$/;"	m	class:Detect
+initialize_biases	yolov6/models/heads/effidehead_lite.py	/^    def initialize_biases(self):$/;"	m	class:Detect
+initialize_weights	yolov6/utils/torch_utils.py	/^def initialize_weights(model):$/;"	f
+input	deploy/ONNX/OpenCV/yolo.py	/^	input = frame.copy()$/;"	v
+input	deploy/ONNX/OpenCV/yolox.py	/^    input = srcimg.copy()$/;"	v	class:yolox
+input_names	deploy/ONNX/export_onnx.py	/^                              input_names=['images'],$/;"	v
+input_names	deploy/OpenVINO/export_openvino.py	/^                          input_names=['image_arrays'],$/;"	v
+input_names	tools/partial_quantization/partial_quant.py	/^                          input_names=['image_arrays'],$/;"	v
+input_names	tools/qat/qat_export.py	/^                          input_names=['images'],$/;"	v
+input_shape	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	const int input_shape[2] = { 640, 640 };   \/\/\/\/ height, width$/;"	m	class:yolox	file:
+intersection_area	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static float intersection_area(const Object& a, const Object& b)$/;"	f	file:
+intersection_area	deploy/TensorRT/yolov6.cpp	/^static inline float intersection_area(const Object& a, const Object& b)$/;"	f	file:
+iou2d_calculator	yolov6/assigners/iou2d_calculator.py	/^def iou2d_calculator(bboxes1, bboxes2, mode='iou', is_aligned=False, scale=1., dtype=None):$/;"	f
+iou_calculator	yolov6/assigners/assigner_utils.py	/^def iou_calculator(box1, box2, eps=1e-9):$/;"	f
+iou_thres	configs/experiment/yolov6n_with_eval_params.py	/^    iou_thres=0.65,$/;"	v
+iou_type	configs/base/yolov6l_base.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6l_base_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6m_base.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6m_base_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6n_base.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6n_base_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6s_base.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/base/yolov6s_base_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/experiment/yolov6n_with_eval_params.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/experiment/yolov6s_csp_scaled.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/experiment/yolov6t.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/experiment/yolov6t_csp_scaled.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/experiment/yolov6t_finetune.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/mbla/yolov6l_mbla.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6l_mbla_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6m_mbla.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6m_mbla_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6s_mbla.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6s_mbla_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6x_mbla.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/mbla/yolov6x_mbla_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/qarepvgg/yolov6m_qa.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/qarepvgg/yolov6n_qa.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/qarepvgg/yolov6s_qa.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/repopt/yolov6_tiny_hs.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/repopt/yolov6_tiny_opt.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/repopt/yolov6_tiny_opt_qat.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/repopt/yolov6n_hs.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/repopt/yolov6n_opt.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/repopt/yolov6n_opt_qat.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/repopt/yolov6s_hs.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/repopt/yolov6s_opt.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/repopt/yolov6s_opt_qat.py	/^        iou_type = 'giou',$/;"	v
+iou_type	configs/yolov6_lite/yolov6_lite_l.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6_lite/yolov6_lite_m.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6_lite/yolov6_lite_s.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6l.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6l6.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6l6_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6l_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6m.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6m6.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6m6_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6m_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6n.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6n6.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6n6_finetune.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6n_finetune.py	/^        iou_type='siou',$/;"	v
+iou_type	configs/yolov6s.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6s6.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6s6_finetune.py	/^        iou_type='giou',$/;"	v
+iou_type	configs/yolov6s_finetune.py	/^        iou_type='giou',$/;"	v
+is_parallel	yolov6/utils/ema.py	/^def is_parallel(model):$/;"	f
+json_load	tools/quantization/ppq/write_qparams_onnx2trt.py	/^def json_load(filename):$/;"	f
+kFAILED	deploy/TensorRT/logging.h	/^        kFAILED,  \/\/!< The test failed$/;"	m	class:Logger::TestResult
+kPASSED	deploy/TensorRT/logging.h	/^        kPASSED,  \/\/!< The test passed$/;"	m	class:Logger::TestResult
+kRUNNING	deploy/TensorRT/logging.h	/^        kRUNNING, \/\/!< The test is running$/;"	m	class:Logger::TestResult
+label	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    int label;$/;"	m	struct:Object
+label	deploy/ONNX/OpenCV/yolo.py	/^	label = 'Average Inference time: %.2f ms' % (avg_time * 1000.0 \/ cv2.getTickFrequency())$/;"	v
+label	deploy/ONNX/OpenCV/yolox.py	/^    label = 'Average inference time: %.2f ms' % (avg_time * 1000.0 \/ cv2.getTickFrequency())$/;"	v	class:yolox
+label	deploy/TensorRT/yolov6.cpp	/^    int label;$/;"	m	struct:Object	file:
+letterbox	deploy/TensorRT/Processor.py	/^def letterbox(im, new_shape=(640, 640), color=(114, 114, 114), auto=True, scaleup=False, stride=32, return_int=False):$/;"	f
+letterbox	deploy/TensorRT/tensorrt_processor.py	/^def letterbox(im, new_shape=(640, 640), color=(114, 114, 114), auto=True, scaleup=False, stride=32):$/;"	f
+letterbox	yolov6/data/data_augment.py	/^def letterbox(im, new_shape=(640, 640), color=(114, 114, 114), auto=True, scaleup=True, stride=32):$/;"	f
+load	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^int Yolo::load(AAssetManager* mgr, const char* modeltype, const int *target_size, const float* _mean_vals, const float* _norm_vals, bool use_gpu)$/;"	f	class:Yolo
+loadModel	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/Yolov6Ncnn.java	/^    public native boolean loadModel(AssetManager mgr, int modelid, int cpugpu);$/;"	m	class:Yolov6Ncnn
+load_batches	tools/quantization/tensorrt/post_training/Calibrator.py	/^    def load_batches(self):$/;"	m	class:ImageCalibrator
+load_checkpoint	yolov6/utils/checkpoint.py	/^def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):$/;"	f
+load_image	yolov6/data/datasets.py	/^    def load_image(self, index, shrink_size=None):$/;"	m	class:TrainValDataset
+load_ptq	tools/partial_quantization/ptq.py	/^def load_ptq(model, calib_path, device):$/;"	f
+load_scale_from_pretrained_models	yolov6/core/engine.py	/^    def load_scale_from_pretrained_models(cfg, device):$/;"	m	class:Trainer
+load_state_dict	yolov6/utils/checkpoint.py	/^def load_state_dict(weights, model, map_location=None):$/;"	f
+load_yaml	yolov6/utils/events.py	/^def load_yaml(file_path):$/;"	f
+lock	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^static ncnn::Mutex lock;$/;"	v	file:
+logger	deploy/TensorRT/calibrator.py	/^logger = logging.getLogger(__name__)$/;"	v
+logger	tools/quantization/tensorrt/post_training/Calibrator.py	/^logger = logging.getLogger(__name__)$/;"	v
+logger	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^logger = logging.getLogger(__name__)$/;"	v
+lr0	configs/base/yolov6l_base.py	/^    lr0=0.01,$/;"	v
+lr0	configs/base/yolov6l_base_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/base/yolov6m_base.py	/^    lr0=0.01,$/;"	v
+lr0	configs/base/yolov6m_base_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/base/yolov6n_base.py	/^    lr0=0.01,$/;"	v
+lr0	configs/base/yolov6n_base_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/base/yolov6s_base.py	/^    lr0=0.01,$/;"	v
+lr0	configs/base/yolov6s_base_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/experiment/yolov6n_with_eval_params.py	/^    lr0=0.02, #0.01 # 0.02$/;"	v
+lr0	configs/experiment/yolov6s_csp_scaled.py	/^    lr0=0.01,$/;"	v
+lr0	configs/experiment/yolov6t.py	/^    lr0=0.01,$/;"	v
+lr0	configs/experiment/yolov6t_csp_scaled.py	/^    lr0=0.01,$/;"	v
+lr0	configs/experiment/yolov6t_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/mbla/yolov6l_mbla.py	/^    lr0=0.01,$/;"	v
+lr0	configs/mbla/yolov6l_mbla_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/mbla/yolov6m_mbla.py	/^    lr0=0.01,$/;"	v
+lr0	configs/mbla/yolov6m_mbla_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/mbla/yolov6s_mbla.py	/^    lr0=0.01,$/;"	v
+lr0	configs/mbla/yolov6s_mbla_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/mbla/yolov6x_mbla.py	/^    lr0=0.01,$/;"	v
+lr0	configs/mbla/yolov6x_mbla_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/qarepvgg/yolov6m_qa.py	/^    lr0=0.01,$/;"	v
+lr0	configs/qarepvgg/yolov6n_qa.py	/^    lr0=0.02,$/;"	v
+lr0	configs/qarepvgg/yolov6s_qa.py	/^    lr0=0.01,$/;"	v
+lr0	configs/repopt/yolov6_tiny_hs.py	/^    lr0=0.01,$/;"	v
+lr0	configs/repopt/yolov6_tiny_opt.py	/^    lr0=0.01,$/;"	v
+lr0	configs/repopt/yolov6_tiny_opt_qat.py	/^    lr0=0.00001,$/;"	v
+lr0	configs/repopt/yolov6n_hs.py	/^    lr0=0.02, #0.01 # 0.02$/;"	v
+lr0	configs/repopt/yolov6n_opt.py	/^    lr0=0.02, #0.01 # 0.02$/;"	v
+lr0	configs/repopt/yolov6n_opt_qat.py	/^    lr0=0.00001, #0.01 # 0.02$/;"	v
+lr0	configs/repopt/yolov6s_hs.py	/^    lr0=0.01,$/;"	v
+lr0	configs/repopt/yolov6s_opt.py	/^    lr0=0.01,$/;"	v
+lr0	configs/repopt/yolov6s_opt_qat.py	/^    lr0=0.00001,$/;"	v
+lr0	configs/yolov6_lite/yolov6_lite_l.py	/^    lr0=0.1 * 4,$/;"	v
+lr0	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6_lite/yolov6_lite_m.py	/^    lr0=0.1 * 4,$/;"	v
+lr0	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6_lite/yolov6_lite_s.py	/^    lr0=0.1 * 4,$/;"	v
+lr0	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6l.py	/^    lr0=0.01,$/;"	v
+lr0	configs/yolov6l6.py	/^    lr0=0.01,$/;"	v
+lr0	configs/yolov6l6_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6l_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6m.py	/^    lr0=0.01,$/;"	v
+lr0	configs/yolov6m6.py	/^    lr0=0.01,$/;"	v
+lr0	configs/yolov6m6_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6m_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6n.py	/^    lr0=0.02,$/;"	v
+lr0	configs/yolov6n6.py	/^    lr0=0.02,$/;"	v
+lr0	configs/yolov6n6_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6n_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6s.py	/^    lr0=0.01,$/;"	v
+lr0	configs/yolov6s6.py	/^    lr0=0.01,$/;"	v
+lr0	configs/yolov6s6_finetune.py	/^    lr0=0.0032,$/;"	v
+lr0	configs/yolov6s_finetune.py	/^    lr0=0.0032,$/;"	v
+lr_scheduler	configs/base/yolov6l_base.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6l_base_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6m_base.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6m_base_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6n_base.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6n_base_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6s_base.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/base/yolov6s_base_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/experiment/yolov6n_with_eval_params.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/experiment/yolov6s_csp_scaled.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/experiment/yolov6t.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/experiment/yolov6t_csp_scaled.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/experiment/yolov6t_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6l_mbla.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6l_mbla_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6m_mbla.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6m_mbla_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6s_mbla.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6s_mbla_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6x_mbla.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/mbla/yolov6x_mbla_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/qarepvgg/yolov6m_qa.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/qarepvgg/yolov6n_qa.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/qarepvgg/yolov6s_qa.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6_tiny_hs.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6_tiny_opt.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6_tiny_opt_qat.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6n_hs.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6n_opt.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6n_opt_qat.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6s_hs.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6s_opt.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/repopt/yolov6s_opt_qat.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6_lite/yolov6_lite_l.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6_lite/yolov6_lite_m.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6_lite/yolov6_lite_s.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6l.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6l6.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6l6_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6l_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6m.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6m6.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6m6_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6m_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6n.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6n6.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6n6_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6n_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6s.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6s6.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6s6_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lr_scheduler	configs/yolov6s_finetune.py	/^    lr_scheduler='Cosine',$/;"	v
+lrf	configs/base/yolov6l_base.py	/^    lrf=0.01,$/;"	v
+lrf	configs/base/yolov6l_base_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/base/yolov6m_base.py	/^    lrf=0.01,$/;"	v
+lrf	configs/base/yolov6m_base_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/base/yolov6n_base.py	/^    lrf=0.01,$/;"	v
+lrf	configs/base/yolov6n_base_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/base/yolov6s_base.py	/^    lrf=0.01,$/;"	v
+lrf	configs/base/yolov6s_base_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/experiment/yolov6n_with_eval_params.py	/^    lrf=0.01,$/;"	v
+lrf	configs/experiment/yolov6s_csp_scaled.py	/^    lrf=0.01,$/;"	v
+lrf	configs/experiment/yolov6t.py	/^    lrf=0.01,$/;"	v
+lrf	configs/experiment/yolov6t_csp_scaled.py	/^    lrf=0.01,$/;"	v
+lrf	configs/experiment/yolov6t_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/mbla/yolov6l_mbla.py	/^    lrf=0.01,$/;"	v
+lrf	configs/mbla/yolov6l_mbla_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/mbla/yolov6m_mbla.py	/^    lrf=0.01,$/;"	v
+lrf	configs/mbla/yolov6m_mbla_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/mbla/yolov6s_mbla.py	/^    lrf=0.01,$/;"	v
+lrf	configs/mbla/yolov6s_mbla_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/mbla/yolov6x_mbla.py	/^    lrf=0.01,$/;"	v
+lrf	configs/mbla/yolov6x_mbla_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/qarepvgg/yolov6m_qa.py	/^    lrf=0.01,$/;"	v
+lrf	configs/qarepvgg/yolov6n_qa.py	/^    lrf=0.01,$/;"	v
+lrf	configs/qarepvgg/yolov6s_qa.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6_tiny_hs.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6_tiny_opt.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6_tiny_opt_qat.py	/^    lrf=0.001,$/;"	v
+lrf	configs/repopt/yolov6n_hs.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6n_opt.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6n_opt_qat.py	/^    lrf=0.001,$/;"	v
+lrf	configs/repopt/yolov6s_hs.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6s_opt.py	/^    lrf=0.01,$/;"	v
+lrf	configs/repopt/yolov6s_opt_qat.py	/^    lrf=0.001,$/;"	v
+lrf	configs/yolov6_lite/yolov6_lite_l.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6_lite/yolov6_lite_m.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6_lite/yolov6_lite_s.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6l.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6l6.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6l6_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6l_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6m.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6m6.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6m6_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6m_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6n.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6n6.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6n6_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6n_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6s.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6s6.py	/^    lrf=0.01,$/;"	v
+lrf	configs/yolov6s6_finetune.py	/^    lrf=0.12,$/;"	v
+lrf	configs/yolov6s_finetune.py	/^    lrf=0.12,$/;"	v
+mBuffer	deploy/TensorRT/logging.h	/^    LogStreamConsumerBuffer mBuffer;$/;"	m	class:LogStreamConsumerBase
+mCmdline	deploy/TensorRT/logging.h	/^        std::string mCmdline;$/;"	m	class:Logger::TestAtom
+mName	deploy/TensorRT/logging.h	/^        std::string mName;$/;"	m	class:Logger::TestAtom
+mOutput	deploy/TensorRT/logging.h	/^    std::ostream& mOutput;$/;"	m	class:LogStreamConsumerBuffer
+mPrefix	deploy/TensorRT/logging.h	/^    std::string mPrefix;$/;"	m	class:LogStreamConsumerBuffer
+mReportableSeverity	deploy/TensorRT/logging.h	/^    Severity mReportableSeverity;$/;"	m	class:Logger
+mSeverity	deploy/TensorRT/logging.h	/^    Severity mSeverity;$/;"	m	class:LogStreamConsumer
+mShouldLog	deploy/TensorRT/logging.h	/^    bool mShouldLog;$/;"	m	class:LogStreamConsumer
+mShouldLog	deploy/TensorRT/logging.h	/^    bool mShouldLog;$/;"	m	class:LogStreamConsumerBuffer
+mStarted	deploy/TensorRT/logging.h	/^        bool mStarted;$/;"	m	class:Logger::TestAtom
+main	deploy/NCNN/infer-ncnn-model.py	/^def main(args: argparse.Namespace):$/;"	f
+main	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^int main(int argc, char** argv)$/;"	f
+main	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^int main(int argc, char** argv)$/;"	f
+main	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^int main(int argc, char** argv)$/;"	f
+main	deploy/ONNX/eval_trt.py	/^def main(args):$/;"	f
+main	deploy/TensorRT/eval_yolo_trt.py	/^def main():$/;"	f
+main	deploy/TensorRT/onnx_to_trt.py	/^def main():$/;"	f
+main	deploy/TensorRT/visualize.py	/^def main():$/;"	f
+main	deploy/TensorRT/yolov6.cpp	/^int main(int argc, char** argv) {$/;"	f
+main	tools/eval.py	/^def main(args):$/;"	f
+main	tools/infer.py	/^def main(args):$/;"	f
+main	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^def main():$/;"	f
+main	tools/train.py	/^def main(args):$/;"	f
+main	yolov6/data/vis_dataset.py	/^def main(args):$/;"	f
+main	yolov6/data/voc2yolo.py	/^def main(args):$/;"	f
+mainEnd	deploy/NCNN/Android/gradlew.bat	/^:mainEnd$/;"	l
+make_divisible	hubconf.py	/^    def make_divisible(x, divisor):$/;"	f	function:check_img_size
+make_divisible	yolov6/core/inferer.py	/^    def make_divisible(self, x, divisor):$/;"	m	class:Inferer
+make_divisible	yolov6/models/yolo.py	/^def make_divisible(x, divisor):$/;"	f
+make_divisible	yolov6/models/yolo_lite.py	/^def make_divisible(v, divisor=16):$/;"	f
+make_divisible	yolov6/utils/general.py	/^def make_divisible(x, divisor):$/;"	f
+mark_outputs	tools/quantization/tensorrt/post_training/onnx_to_tensorrt.py	/^def mark_outputs(network):$/;"	f
+matrix	yolov6/utils/metrics.py	/^    def matrix(self):$/;"	m	class:ConfusionMatrix
+mean	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	const float mean[3] = { 0.485, 0.456, 0.406 };$/;"	m	class:yolox	file:
+mean_vals	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    float mean_vals[3];$/;"	m	class:Yolo
+mixup	configs/base/yolov6l_base.py	/^    mixup=0.1,$/;"	v
+mixup	configs/base/yolov6l_base_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/base/yolov6m_base.py	/^    mixup=0.1,$/;"	v
+mixup	configs/base/yolov6m_base_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/base/yolov6n_base.py	/^    mixup=0.0,$/;"	v
+mixup	configs/base/yolov6n_base_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/base/yolov6s_base.py	/^    mixup=0.0,$/;"	v
+mixup	configs/base/yolov6s_base_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/experiment/yolov6n_with_eval_params.py	/^    mixup=0.0,$/;"	v
+mixup	configs/experiment/yolov6s_csp_scaled.py	/^    mixup=0.1,$/;"	v
+mixup	configs/experiment/yolov6t.py	/^    mixup=0.0,$/;"	v
+mixup	configs/experiment/yolov6t_csp_scaled.py	/^    mixup=0.1,$/;"	v
+mixup	configs/experiment/yolov6t_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/mbla/yolov6l_mbla.py	/^    mixup=0.1,$/;"	v
+mixup	configs/mbla/yolov6l_mbla_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/mbla/yolov6m_mbla.py	/^    mixup=0.1,$/;"	v
+mixup	configs/mbla/yolov6m_mbla_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/mbla/yolov6s_mbla.py	/^    mixup=0.1,$/;"	v
+mixup	configs/mbla/yolov6s_mbla_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/mbla/yolov6x_mbla.py	/^    mixup=0.1,$/;"	v
+mixup	configs/mbla/yolov6x_mbla_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/qarepvgg/yolov6m_qa.py	/^    mixup=0.1,$/;"	v
+mixup	configs/qarepvgg/yolov6n_qa.py	/^    mixup=0.0,$/;"	v
+mixup	configs/qarepvgg/yolov6s_qa.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6_tiny_hs.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6_tiny_opt.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6_tiny_opt_qat.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6n_hs.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6n_opt.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6n_opt_qat.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6s_hs.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6s_opt.py	/^    mixup=0.0,$/;"	v
+mixup	configs/repopt/yolov6s_opt_qat.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6_lite/yolov6_lite_l.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6_lite/yolov6_lite_m.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6_lite/yolov6_lite_s.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6l.py	/^    mixup=0.1,$/;"	v
+mixup	configs/yolov6l6.py	/^    mixup=0.2,$/;"	v
+mixup	configs/yolov6l6_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6l_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6m.py	/^    mixup=0.1,$/;"	v
+mixup	configs/yolov6m6.py	/^    mixup=0.1,$/;"	v
+mixup	configs/yolov6m6_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6m_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6n.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6n6.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6n6_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6n_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6s.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6s6.py	/^    mixup=0.0,$/;"	v
+mixup	configs/yolov6s6_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	configs/yolov6s_finetune.py	/^    mixup=0.243,$/;"	v
+mixup	yolov6/data/data_augment.py	/^def mixup(im, labels, im2, labels2):$/;"	f
+model	configs/base/yolov6l_base.py	/^model = dict($/;"	v
+model	configs/base/yolov6l_base_finetune.py	/^model = dict($/;"	v
+model	configs/base/yolov6m_base.py	/^model = dict($/;"	v
+model	configs/base/yolov6m_base_finetune.py	/^model = dict($/;"	v
+model	configs/base/yolov6n_base.py	/^model = dict($/;"	v
+model	configs/base/yolov6n_base_finetune.py	/^model = dict($/;"	v
+model	configs/base/yolov6s_base.py	/^model = dict($/;"	v
+model	configs/base/yolov6s_base_finetune.py	/^model = dict($/;"	v
+model	configs/experiment/yolov6n_with_eval_params.py	/^model = dict($/;"	v
+model	configs/experiment/yolov6s_csp_scaled.py	/^model = dict($/;"	v
+model	configs/experiment/yolov6t.py	/^model = dict($/;"	v
+model	configs/experiment/yolov6t_csp_scaled.py	/^model = dict($/;"	v
+model	configs/experiment/yolov6t_finetune.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6l_mbla.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6l_mbla_finetune.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6m_mbla.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6m_mbla_finetune.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6s_mbla.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6s_mbla_finetune.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6x_mbla.py	/^model = dict($/;"	v
+model	configs/mbla/yolov6x_mbla_finetune.py	/^model = dict($/;"	v
+model	configs/qarepvgg/yolov6m_qa.py	/^model = dict($/;"	v
+model	configs/qarepvgg/yolov6n_qa.py	/^model = dict($/;"	v
+model	configs/qarepvgg/yolov6s_qa.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6_tiny_hs.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6_tiny_opt.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6_tiny_opt_qat.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6n_hs.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6n_opt.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6n_opt_qat.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6s_hs.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6s_opt.py	/^model = dict($/;"	v
+model	configs/repopt/yolov6s_opt_qat.py	/^model = dict($/;"	v
+model	configs/yolov6_lite/yolov6_lite_l.py	/^model = dict($/;"	v
+model	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6_lite/yolov6_lite_m.py	/^model = dict($/;"	v
+model	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6_lite/yolov6_lite_s.py	/^model = dict($/;"	v
+model	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6l.py	/^model = dict($/;"	v
+model	configs/yolov6l6.py	/^model = dict($/;"	v
+model	configs/yolov6l6_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6l_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6m.py	/^model = dict($/;"	v
+model	configs/yolov6m6.py	/^model = dict($/;"	v
+model	configs/yolov6m6_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6m_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6n.py	/^model = dict($/;"	v
+model	configs/yolov6n6.py	/^model = dict($/;"	v
+model	configs/yolov6n6_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6n_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6s.py	/^model = dict($/;"	v
+model	configs/yolov6s6.py	/^model = dict($/;"	v
+model	configs/yolov6s6_finetune.py	/^model = dict($/;"	v
+model	configs/yolov6s_finetune.py	/^model = dict($/;"	v
+model	deploy/NCNN/export_torchscript.py	/^    model = load_checkpoint(args.weights, map_location=device, inplace=True, fuse=True)  # load FP32 model$/;"	v
+model	deploy/ONNX/export_onnx.py	/^        model = End2End(model, max_obj=args.topk_all, iou_thres=args.iou_thres,score_thres=args.conf_thres,$/;"	v
+model	deploy/ONNX/export_onnx.py	/^    model = load_checkpoint(args.weights, map_location=device, inplace=True, fuse=True)  # load FP32 model$/;"	v
+model	deploy/OpenVINO/export_openvino.py	/^    model = load_checkpoint(args.weights, map_location=device, inplace=True, fuse=True)  # load FP32 model$/;"	v
+model	tools/partial_quantization/partial_quant.py	/^    model = load_checkpoint(args.weights, map_location=device, inplace=True, fuse=True)  # load FP32 model$/;"	v
+model	tools/partial_quantization/sensitivity_analyse.py	/^    model = load_checkpoint(args.weights, map_location=device, inplace=True, fuse=True)  # load FP32 model$/;"	v
+model	tools/qat/qat_export.py	/^        model = End2End(model, max_obj=args.topk_all, iou_thres=args.iou_thres,score_thres=args.conf_thres,$/;"	v
+model	tools/qat/qat_export.py	/^    model = load_checkpoint(args.weights, map_location=device, inplace=args.inplace, fuse=args.fuse_bn)$/;"	v
+model_ptq	tools/partial_quantization/partial_quant.py	/^    model_ptq = load_ptq(model, args.calib_weights, device)$/;"	v
+model_ptq	tools/partial_quantization/sensitivity_analyse.py	/^        model_ptq = load_ptq(model, args.calib_weights, device)$/;"	v
+model_ptq	tools/partial_quantization/sensitivity_analyse.py	/^        model_ptq= do_ptq(model, train_loader, args.batch_number, device)$/;"	v
+model_quant_disable	tools/partial_quantization/utils.py	/^def model_quant_disable(model):$/;"	f
+model_quant_enable	tools/partial_quantization/utils.py	/^def model_quant_enable(model):$/;"	f
+model_switch	yolov6/core/inferer.py	/^    def model_switch(self, model, img_size):$/;"	m	class:Inferer
+module_quant_disable	tools/partial_quantization/utils.py	/^def module_quant_disable(model, k):$/;"	f
+module_quant_enable	tools/partial_quantization/utils.py	/^def module_quant_enable(model, k):$/;"	f
+momentum	configs/base/yolov6l_base.py	/^    momentum=0.937,$/;"	v
+momentum	configs/base/yolov6l_base_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/base/yolov6m_base.py	/^    momentum=0.937,$/;"	v
+momentum	configs/base/yolov6m_base_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/base/yolov6n_base.py	/^    momentum=0.937,$/;"	v
+momentum	configs/base/yolov6n_base_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/base/yolov6s_base.py	/^    momentum=0.937,$/;"	v
+momentum	configs/base/yolov6s_base_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/experiment/yolov6n_with_eval_params.py	/^    momentum=0.937,$/;"	v
+momentum	configs/experiment/yolov6s_csp_scaled.py	/^    momentum=0.937,$/;"	v
+momentum	configs/experiment/yolov6t.py	/^    momentum=0.937,$/;"	v
+momentum	configs/experiment/yolov6t_csp_scaled.py	/^    momentum=0.937,$/;"	v
+momentum	configs/experiment/yolov6t_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/mbla/yolov6l_mbla.py	/^    momentum=0.937,$/;"	v
+momentum	configs/mbla/yolov6l_mbla_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/mbla/yolov6m_mbla.py	/^    momentum=0.937,$/;"	v
+momentum	configs/mbla/yolov6m_mbla_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/mbla/yolov6s_mbla.py	/^    momentum=0.937,$/;"	v
+momentum	configs/mbla/yolov6s_mbla_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/mbla/yolov6x_mbla.py	/^    momentum=0.937,$/;"	v
+momentum	configs/mbla/yolov6x_mbla_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/qarepvgg/yolov6m_qa.py	/^    momentum=0.937,$/;"	v
+momentum	configs/qarepvgg/yolov6n_qa.py	/^    momentum=0.937,$/;"	v
+momentum	configs/qarepvgg/yolov6s_qa.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6_tiny_hs.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6_tiny_opt.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6_tiny_opt_qat.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6n_hs.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6n_opt.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6n_opt_qat.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6s_hs.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6s_opt.py	/^    momentum=0.937,$/;"	v
+momentum	configs/repopt/yolov6s_opt_qat.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6_lite/yolov6_lite_l.py	/^    momentum=0.9,$/;"	v
+momentum	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6_lite/yolov6_lite_m.py	/^    momentum=0.9,$/;"	v
+momentum	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6_lite/yolov6_lite_s.py	/^    momentum=0.9,$/;"	v
+momentum	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6l.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6l6.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6l6_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6l_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6m.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6m6.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6m6_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6m_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6n.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6n6.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6n6_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6n_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6s.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6s6.py	/^    momentum=0.937,$/;"	v
+momentum	configs/yolov6s6_finetune.py	/^    momentum=0.843,$/;"	v
+momentum	configs/yolov6s_finetune.py	/^    momentum=0.843,$/;"	v
+mosaic	configs/base/yolov6l_base.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6l_base_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6m_base.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6m_base_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6n_base.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6n_base_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6s_base.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/base/yolov6s_base_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/experiment/yolov6n_with_eval_params.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/experiment/yolov6s_csp_scaled.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/experiment/yolov6t.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/experiment/yolov6t_csp_scaled.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/experiment/yolov6t_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6l_mbla.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6l_mbla_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6m_mbla.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6m_mbla_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6s_mbla.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6s_mbla_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6x_mbla.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/mbla/yolov6x_mbla_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/qarepvgg/yolov6m_qa.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/qarepvgg/yolov6n_qa.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/qarepvgg/yolov6s_qa.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6_tiny_hs.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6_tiny_opt.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6_tiny_opt_qat.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6n_hs.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6n_opt.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6n_opt_qat.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6s_hs.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6s_opt.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/repopt/yolov6s_opt_qat.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6_lite/yolov6_lite_l.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6_lite/yolov6_lite_m.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6_lite/yolov6_lite_s.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6l.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6l6.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6l6_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6l_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6m.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6m6.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6m6_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6m_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6n.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6n6.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6n6_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6n_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6s.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6s6.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6s6_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic	configs/yolov6s_finetune.py	/^    mosaic=1.0,$/;"	v
+mosaic_augmentation	yolov6/data/data_augment.py	/^def mosaic_augmentation(shape, imgs, hs, ws, labels, hyp, specific_shape = False, target_height=640, target_width=640):$/;"	f
+multiclass_nms	deploy/ONNX/OpenCV/yolox.py	/^    def multiclass_nms(self, boxes, scores):$/;"	m	class:yolox
+neck	configs/base/yolov6l_base.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6l_base_finetune.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6m_base.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6m_base_finetune.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6n_base.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6n_base_finetune.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6s_base.py	/^    neck=dict($/;"	v
+neck	configs/base/yolov6s_base_finetune.py	/^    neck=dict($/;"	v
+neck	configs/experiment/yolov6n_with_eval_params.py	/^    neck=dict($/;"	v
+neck	configs/experiment/yolov6s_csp_scaled.py	/^    neck=dict($/;"	v
+neck	configs/experiment/yolov6t.py	/^    neck=dict($/;"	v
+neck	configs/experiment/yolov6t_csp_scaled.py	/^    neck=dict($/;"	v
+neck	configs/experiment/yolov6t_finetune.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6l_mbla.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6l_mbla_finetune.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6m_mbla.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6m_mbla_finetune.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6s_mbla.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6s_mbla_finetune.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6x_mbla.py	/^    neck=dict($/;"	v
+neck	configs/mbla/yolov6x_mbla_finetune.py	/^    neck=dict($/;"	v
+neck	configs/qarepvgg/yolov6m_qa.py	/^    neck=dict($/;"	v
+neck	configs/qarepvgg/yolov6n_qa.py	/^    neck=dict($/;"	v
+neck	configs/qarepvgg/yolov6s_qa.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6_tiny_hs.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6_tiny_opt.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6_tiny_opt_qat.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6n_hs.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6n_opt.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6n_opt_qat.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6s_hs.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6s_opt.py	/^    neck=dict($/;"	v
+neck	configs/repopt/yolov6s_opt_qat.py	/^    neck=dict($/;"	v
+neck	configs/yolov6_lite/yolov6_lite_l.py	/^    neck=dict($/;"	v
+neck	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6_lite/yolov6_lite_m.py	/^    neck=dict($/;"	v
+neck	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6_lite/yolov6_lite_s.py	/^    neck=dict($/;"	v
+neck	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6l.py	/^    neck=dict($/;"	v
+neck	configs/yolov6l6.py	/^    neck=dict($/;"	v
+neck	configs/yolov6l6_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6l_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6m.py	/^    neck=dict($/;"	v
+neck	configs/yolov6m6.py	/^    neck=dict($/;"	v
+neck	configs/yolov6m6_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6m_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6n.py	/^    neck=dict($/;"	v
+neck	configs/yolov6n6.py	/^    neck=dict($/;"	v
+neck	configs/yolov6n6_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6n_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6s.py	/^    neck=dict($/;"	v
+neck	configs/yolov6s6.py	/^    neck=dict($/;"	v
+neck	configs/yolov6s6_finetune.py	/^    neck=dict($/;"	v
+neck	configs/yolov6s_finetune.py	/^    neck=dict($/;"	v
+net	deploy/ONNX/OpenCV/yolo.py	/^	net = cv2.dnn.readNet(model_path)$/;"	v
+net	deploy/ONNX/OpenCV/yolox.py	/^    net = yolox(args.model, args.classesFile, p6=args.with_p6, confThreshold=args.score_thr)$/;"	v	class:yolox
+net	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^    Net net;$/;"	m	class:yolox	file:
+net_h	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    int net_h;$/;"	m	class:Yolo
+net_w	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    int net_w;$/;"	m	class:Yolo
+next_batch	deploy/TensorRT/calibrator.py	/^    def next_batch(self):$/;"	m	class:DataLoader
+nms	deploy/ONNX/OpenCV/yolox.py	/^    def nms(self, boxes, scores):$/;"	m	class:yolox
+nms_forward_function	tools/quantization/ppq/ProgramEntrance.py	/^def nms_forward_function(op: Operation, values: List[torch.Tensor], **kwards) -> List[torch.Tensor]:$/;"	f
+nms_sorted_bboxes	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)$/;"	f	file:
+nms_sorted_bboxes	deploy/TensorRT/yolov6.cpp	/^static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)$/;"	f	file:
+nms_threshold	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	float nms_threshold;$/;"	m	class:yolox	file:
+non_max_suppression	deploy/TensorRT/Processor.py	/^    def non_max_suppression(self, prediction, conf_thres=0.25, iou_thres=0.45, classes=None, agnostic=False, multi_label=False, max_det=300):$/;"	m	class:Processor
+non_max_suppression	deploy/TensorRT/tensorrt_processor.py	/^    def non_max_suppression(self, prediction, conf_thres=0.25, iou_thres=0.45, classes=None, agnostic=False, multi_label=False, max_det=300):$/;"	m	class:Processor
+non_max_suppression	yolov6/utils/nms.py	/^def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=None, agnostic=False, multi_label=False, max_det=300):$/;"	f
+norm_vals	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    float norm_vals[3];$/;"	m	class:Yolo
+normalize	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^void yolox::normalize(Mat& img)$/;"	f	class:yolox
+num_bits	configs/repopt/yolov6_tiny_opt_qat.py	/^    num_bits = 8,$/;"	v
+num_bits	configs/repopt/yolov6n_opt_qat.py	/^    num_bits = 8,$/;"	v
+num_bits	configs/repopt/yolov6s_opt_qat.py	/^    num_bits = 8,$/;"	v
+num_class	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	int num_class;$/;"	m	class:yolox	file:
+num_class	deploy/TensorRT/yolov6.cpp	/^const int num_class = 80;$/;"	v
+num_layers	configs/base/yolov6l_base.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6l_base_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6m_base.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6m_base_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6n_base.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6n_base_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6s_base.py	/^        num_layers=3,$/;"	v
+num_layers	configs/base/yolov6s_base_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/experiment/yolov6n_with_eval_params.py	/^        num_layers=3,$/;"	v
+num_layers	configs/experiment/yolov6s_csp_scaled.py	/^        num_layers=3,$/;"	v
+num_layers	configs/experiment/yolov6t.py	/^        num_layers=3,$/;"	v
+num_layers	configs/experiment/yolov6t_csp_scaled.py	/^        num_layers=3,$/;"	v
+num_layers	configs/experiment/yolov6t_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6l_mbla.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6l_mbla_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6m_mbla.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6m_mbla_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6s_mbla.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6s_mbla_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6x_mbla.py	/^        num_layers=3,$/;"	v
+num_layers	configs/mbla/yolov6x_mbla_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/qarepvgg/yolov6m_qa.py	/^        num_layers=3,$/;"	v
+num_layers	configs/qarepvgg/yolov6n_qa.py	/^        num_layers=3,$/;"	v
+num_layers	configs/qarepvgg/yolov6s_qa.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6_tiny_hs.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6_tiny_opt.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6_tiny_opt_qat.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6n_hs.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6n_opt.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6n_opt_qat.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6s_hs.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6s_opt.py	/^        num_layers=3,$/;"	v
+num_layers	configs/repopt/yolov6s_opt_qat.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6_lite/yolov6_lite_l.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6_lite/yolov6_lite_m.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6_lite/yolov6_lite_s.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6l.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6l6.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6l6_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6l_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6m.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6m6.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6m6_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6m_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6n.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6n6.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6n6_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6n_finetune.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6s.py	/^        num_layers=3,$/;"	v
+num_layers	configs/yolov6s6.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6s6_finetune.py	/^        num_layers=4,$/;"	v
+num_layers	configs/yolov6s_finetune.py	/^        num_layers=3,$/;"	v
+num_repeats	configs/base/yolov6l_base.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6l_base.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6l_base_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6l_base_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6m_base.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6m_base.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6m_base_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6m_base_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6n_base.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6n_base.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6n_base_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6n_base_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6s_base.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6s_base.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/base/yolov6s_base_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/base/yolov6s_base_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/experiment/yolov6n_with_eval_params.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/experiment/yolov6n_with_eval_params.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/experiment/yolov6s_csp_scaled.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/experiment/yolov6s_csp_scaled.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/experiment/yolov6t.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/experiment/yolov6t.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/experiment/yolov6t_csp_scaled.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/experiment/yolov6t_csp_scaled.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/experiment/yolov6t_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/experiment/yolov6t_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/mbla/yolov6l_mbla.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6l_mbla.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6l_mbla_finetune.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6l_mbla_finetune.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6m_mbla.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6m_mbla.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6m_mbla_finetune.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6m_mbla_finetune.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6s_mbla.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6s_mbla.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6s_mbla_finetune.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6s_mbla_finetune.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6x_mbla.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6x_mbla.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/mbla/yolov6x_mbla_finetune.py	/^        num_repeats=[1, 4, 8, 8, 4],$/;"	v
+num_repeats	configs/mbla/yolov6x_mbla_finetune.py	/^        num_repeats=[8, 8, 8, 8],$/;"	v
+num_repeats	configs/qarepvgg/yolov6m_qa.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/qarepvgg/yolov6m_qa.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/qarepvgg/yolov6n_qa.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/qarepvgg/yolov6n_qa.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/qarepvgg/yolov6s_qa.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/qarepvgg/yolov6s_qa.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6_tiny_hs.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6_tiny_hs.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6_tiny_opt.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6_tiny_opt.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6_tiny_opt_qat.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6_tiny_opt_qat.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6n_hs.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6n_hs.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6n_opt.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6n_opt.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6n_opt_qat.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6n_opt_qat.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6s_hs.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6s_hs.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6s_opt.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6s_opt.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/repopt/yolov6s_opt_qat.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/repopt/yolov6s_opt_qat.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6_lite/yolov6_lite_l.py	/^        num_repeats=[1, 3, 7, 3],$/;"	v
+num_repeats	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        num_repeats=[1, 3, 7, 3],$/;"	v
+num_repeats	configs/yolov6_lite/yolov6_lite_m.py	/^        num_repeats=[1, 3, 7, 3],$/;"	v
+num_repeats	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        num_repeats=[1, 3, 7, 3],$/;"	v
+num_repeats	configs/yolov6_lite/yolov6_lite_s.py	/^        num_repeats=[1, 3, 7, 3],$/;"	v
+num_repeats	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        num_repeats=[1, 3, 7, 3],$/;"	v
+num_repeats	configs/yolov6l.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6l.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6l6.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6l6.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6l6_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6l6_finetune.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6l_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6l_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6m.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6m.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6m6.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6m6.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6m6_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6m6_finetune.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6m_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6m_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6n.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6n.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6n6.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6n6.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6n6_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6n6_finetune.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6n_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6n_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6s.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6s.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6s6.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6s6.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6s6_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6, 6],$/;"	v
+num_repeats	configs/yolov6s6_finetune.py	/^        num_repeats=[12, 12, 12, 12, 12, 12],$/;"	v
+num_repeats	configs/yolov6s_finetune.py	/^        num_repeats=[1, 6, 12, 18, 6],$/;"	v
+num_repeats	configs/yolov6s_finetune.py	/^        num_repeats=[12, 12, 12, 12],$/;"	v
+observer_algorithm	tools/quantization/ppq/ProgramEntrance.py	/^    observer_algorithm='minmax'$/;"	v
+omega	deploy/NCNN/Android/gradlew.bat	/^:omega$/;"	l
+onCaptureCompleted	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void onCaptureCompleted(void* context, ACameraCaptureSession* session, ACaptureRequest* request, const ACameraMetadata* result)$/;"	f
+onCaptureFailed	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void onCaptureFailed(void* context, ACameraCaptureSession* session, ACaptureRequest* request, ACameraCaptureFailure* failure)$/;"	f
+onCaptureSequenceAborted	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void onCaptureSequenceAborted(void* context, ACameraCaptureSession* session, int sequenceId)$/;"	f
+onCaptureSequenceCompleted	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void onCaptureSequenceCompleted(void* context, ACameraCaptureSession* session, int sequenceId, int64_t frameNumber)$/;"	f
+onCreate	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public void onCreate(Bundle savedInstanceState)$/;"	m	class:MainActivity
+onDisconnected	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static void onDisconnected(void* context, ACameraDevice* device)$/;"	f	file:
+onError	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static void onError(void* context, ACameraDevice* device, int error)$/;"	f	file:
+onImageAvailable	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static void onImageAvailable(void* context, AImageReader* reader)$/;"	f	file:
+onPause	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public void onPause()$/;"	m	class:MainActivity
+onResume	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public void onResume()$/;"	m	class:MainActivity
+onSessionActive	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static void onSessionActive(void* context, ACameraCaptureSession *session)$/;"	f	file:
+onSessionClosed	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static void onSessionClosed(void* context, ACameraCaptureSession *session)$/;"	f	file:
+onSessionReady	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^static void onSessionReady(void* context, ACameraCaptureSession *session)$/;"	f	file:
+on_image	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void NdkCamera::on_image(const cv::Mat& rgb) const$/;"	f	class:NdkCamera
+on_image	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void NdkCamera::on_image(const unsigned char* nv21, int nv21_width, int nv21_height) const$/;"	f	class:NdkCamera
+on_image	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void NdkCameraWindow::on_image(const unsigned char* nv21, int nv21_width, int nv21_height) const$/;"	f	class:NdkCameraWindow
+on_image_render	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void NdkCameraWindow::on_image_render(cv::Mat& rgb) const$/;"	f	class:NdkCameraWindow
+on_image_render	deploy/NCNN/Android/app/src/main/jni/yolov6ncnn.cpp	/^void MyNdkCamera::on_image_render(cv::Mat& rgb) const$/;"	f	class:MyNdkCamera
+onnx_add_insert_qdqnode	tools/qat/onnx_utils.py	/^def onnx_add_insert_qdqnode(onnx_model):$/;"	f
+onnx_conv_horizon_fuse	tools/qat/onnx_utils.py	/^def onnx_conv_horizon_fuse(onnx_model):$/;"	f
+onnx_file	tools/qat/onnx_utils.py	/^    onnx_file = sys.argv[1]$/;"	v
+onnx_model	deploy/ONNX/export_onnx.py	/^            onnx_model = onnx.load(f)  # load onnx model$/;"	v
+onnx_model	deploy/OpenVINO/export_openvino.py	/^        onnx_model = onnx.load(export_file)  # load onnx model$/;"	v
+onnx_remove_qdqnode	tools/qat/onnx_utils.py	/^def onnx_remove_qdqnode(onnx_model):$/;"	f
+op_concat_fusion_list	tools/partial_quantization/partial_quant.py	/^op_concat_fusion_list = [$/;"	v
+op_concat_fusion_list	tools/qat/qat_export.py	/^op_concat_fusion_list = [$/;"	v
+open	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^int NdkCamera::open(int _camera_facing)$/;"	f	class:NdkCamera
+openCamera	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/Yolov6Ncnn.java	/^    public native boolean openCamera(int facing);$/;"	m	class:Yolov6Ncnn
+ops	tools/partial_quantization/partial_quant.py	/^        ops = [get_module(model_ptq, op_name) for op_name in sub_fusion_list]$/;"	v
+ops	tools/qat/qat_export.py	/^            ops = [get_module(model, op_name) for op_name in sub_fusion_list]$/;"	v
+opset_version	tools/partial_quantization/partial_quant.py	/^                          opset_version=13,$/;"	v
+opset_version	tools/qat/qat_export.py	/^                          opset_version=13,$/;"	v
+optim	configs/base/yolov6l_base.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6l_base_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6m_base.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6m_base_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6n_base.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6n_base_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6s_base.py	/^    optim='SGD',$/;"	v
+optim	configs/base/yolov6s_base_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/experiment/yolov6n_with_eval_params.py	/^    optim='SGD',$/;"	v
+optim	configs/experiment/yolov6s_csp_scaled.py	/^    optim='SGD',$/;"	v
+optim	configs/experiment/yolov6t.py	/^    optim='SGD',$/;"	v
+optim	configs/experiment/yolov6t_csp_scaled.py	/^    optim='SGD',$/;"	v
+optim	configs/experiment/yolov6t_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6l_mbla.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6l_mbla_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6m_mbla.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6m_mbla_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6s_mbla.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6s_mbla_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6x_mbla.py	/^    optim='SGD',$/;"	v
+optim	configs/mbla/yolov6x_mbla_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/qarepvgg/yolov6m_qa.py	/^    optim='SGD',$/;"	v
+optim	configs/qarepvgg/yolov6n_qa.py	/^    optim='SGD',$/;"	v
+optim	configs/qarepvgg/yolov6s_qa.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6_tiny_hs.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6_tiny_opt.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6_tiny_opt_qat.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6n_hs.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6n_opt.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6n_opt_qat.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6s_hs.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6s_opt.py	/^    optim='SGD',$/;"	v
+optim	configs/repopt/yolov6s_opt_qat.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6_lite/yolov6_lite_l.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6_lite/yolov6_lite_m.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6_lite/yolov6_lite_s.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6l.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6l6.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6l6_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6l_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6m.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6m6.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6m6_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6m_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6n.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6n6.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6n6_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6n_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6s.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6s6.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6s6_finetune.py	/^    optim='SGD',$/;"	v
+optim	configs/yolov6s_finetune.py	/^    optim='SGD',$/;"	v
+orig_mAP	tools/partial_quantization/partial_quant.py	/^    orig_mAP = yolov6_evaler.eval(model)$/;"	v
+orig_mAP	tools/partial_quantization/sensitivity_analyse.py	/^    orig_mAP = yolov6_evaler.eval(model)$/;"	v
+out_channels	configs/base/yolov6l_base.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6l_base.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6l_base_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6l_base_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6m_base.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6m_base.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6m_base_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6m_base_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6n_base.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6n_base.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6n_base_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6n_base_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6s_base.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6s_base.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/base/yolov6s_base_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/base/yolov6s_base_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/experiment/yolov6n_with_eval_params.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/experiment/yolov6n_with_eval_params.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/experiment/yolov6s_csp_scaled.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/experiment/yolov6s_csp_scaled.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/experiment/yolov6t.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/experiment/yolov6t.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/experiment/yolov6t_csp_scaled.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/experiment/yolov6t_csp_scaled.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/experiment/yolov6t_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/experiment/yolov6t_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6l_mbla.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6l_mbla.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6l_mbla_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6l_mbla_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6m_mbla.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6m_mbla.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6m_mbla_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6m_mbla_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6s_mbla.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6s_mbla.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6s_mbla_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6s_mbla_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6x_mbla.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6x_mbla.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/mbla/yolov6x_mbla_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/mbla/yolov6x_mbla_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/qarepvgg/yolov6m_qa.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/qarepvgg/yolov6m_qa.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/qarepvgg/yolov6n_qa.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/qarepvgg/yolov6n_qa.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/qarepvgg/yolov6s_qa.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/qarepvgg/yolov6s_qa.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6_tiny_hs.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6_tiny_hs.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6_tiny_opt.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6_tiny_opt.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6_tiny_opt_qat.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6_tiny_opt_qat.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6n_hs.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6n_hs.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6n_opt.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6n_opt.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6n_opt_qat.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6n_opt_qat.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6s_hs.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6s_hs.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6s_opt.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6s_opt.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/repopt/yolov6s_opt_qat.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/repopt/yolov6s_opt_qat.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6_lite/yolov6_lite_l.py	/^        out_channels=[24, 32, 64, 128, 256],$/;"	v
+out_channels	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        out_channels=[24, 32, 64, 128, 256],$/;"	v
+out_channels	configs/yolov6_lite/yolov6_lite_m.py	/^        out_channels=[24, 32, 64, 128, 256],$/;"	v
+out_channels	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        out_channels=[24, 32, 64, 128, 256],$/;"	v
+out_channels	configs/yolov6_lite/yolov6_lite_s.py	/^        out_channels=[24, 32, 64, 128, 256],$/;"	v
+out_channels	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        out_channels=[24, 32, 64, 128, 256],$/;"	v
+out_channels	configs/yolov6l.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6l.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6l6.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6l6.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6l6_finetune.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6l6_finetune.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6l_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6l_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6m.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6m.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6m6.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6m6.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6m6_finetune.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6m6_finetune.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6m_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6m_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6n.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6n.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6n6.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6n6.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6n6_finetune.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6n6_finetune.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6n_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6n_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6s.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6s.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6s6.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6s6.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6s6_finetune.py	/^        out_channels=[512, 256, 128, 256, 512, 1024],$/;"	v
+out_channels	configs/yolov6s6_finetune.py	/^        out_channels=[64, 128, 256, 512, 768, 1024],$/;"	v
+out_channels	configs/yolov6s_finetune.py	/^        out_channels=[256, 128, 128, 256, 256, 512],$/;"	v
+out_channels	configs/yolov6s_finetune.py	/^        out_channels=[64, 128, 256, 512, 1024],$/;"	v
+out_indices	configs/base/yolov6l_base.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6l_base_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6m_base.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6m_base_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6n_base.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6n_base_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6s_base.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/base/yolov6s_base_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/experiment/yolov6n_with_eval_params.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/experiment/yolov6s_csp_scaled.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/experiment/yolov6t.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/experiment/yolov6t_csp_scaled.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/experiment/yolov6t_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6l_mbla.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6l_mbla_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6m_mbla.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6m_mbla_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6s_mbla.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6s_mbla_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6x_mbla.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/mbla/yolov6x_mbla_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/qarepvgg/yolov6m_qa.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/qarepvgg/yolov6n_qa.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/qarepvgg/yolov6s_qa.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6_tiny_hs.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6_tiny_opt.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6_tiny_opt_qat.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6n_hs.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6n_opt.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6n_opt_qat.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6s_hs.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6s_opt.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/repopt/yolov6s_opt_qat.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6l.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6l_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6m.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6m_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6n.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6n_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6s.py	/^        out_indices=[17, 20, 23],$/;"	v
+out_indices	configs/yolov6s_finetune.py	/^        out_indices=[17, 20, 23],$/;"	v
+output_axes	deploy/ONNX/export_onnx.py	/^            output_axes = {$/;"	v
+output_names	deploy/ONNX/export_onnx.py	/^                              output_names=['num_dets', 'det_boxes', 'det_scores', 'det_classes']$/;"	v
+output_names	deploy/OpenVINO/export_openvino.py	/^                          output_names=['outputs'],$/;"	v
+output_names	tools/partial_quantization/partial_quant.py	/^                          output_names=['outputs']$/;"	v
+output_names	tools/partial_quantization/partial_quant.py	/^                          output_names=['outputs'],$/;"	v
+output_names	tools/qat/qat_export.py	/^                          output_names=['num_dets', 'det_boxes', 'det_scores', 'det_classes']$/;"	v
+output_reformate	deploy/TensorRT/Processor.py	/^    def output_reformate(self, outputs):$/;"	m	class:Processor
+output_reformate	deploy/TensorRT/tensorrt_processor.py	/^    def output_reformate(self, outputs):$/;"	m	class:Processor
+pairwise_bbox_iou	yolov6/utils/figure_iou.py	/^def pairwise_bbox_iou(box1, box2, box_format='xywh'):$/;"	f
+parallel_model	yolov6/core/engine.py	/^    def parallel_model(args, model, device):$/;"	m	class:Trainer
+parse_args	deploy/NCNN/infer-ncnn-model.py	/^def parse_args() -> argparse.Namespace:$/;"	f
+parse_args	deploy/TensorRT/eval_yolo_trt.py	/^def parse_args():$/;"	f
+parse_args	deploy/TensorRT/visualize.py	/^def parse_args():$/;"	f
+parser	deploy/NCNN/export_torchscript.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	deploy/ONNX/OpenCV/yolo.py	/^	parser = argparse.ArgumentParser()$/;"	v
+parser	deploy/ONNX/OpenCV/yolo_video.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	deploy/ONNX/OpenCV/yolox.py	/^    parser = argparse.ArgumentParser("opencv inference sample")$/;"	v	class:yolox
+parser	deploy/ONNX/export_onnx.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	deploy/OpenVINO/export_openvino.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	tools/partial_quantization/partial_quant.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	tools/partial_quantization/sensitivity_analyse.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	tools/qat/qat_export.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	tools/quantization/ppq/write_qparams_onnx2trt.py	/^    parser = argparse.ArgumentParser(description='Writing qparams to onnx to convert tensorrt engine.')$/;"	v
+parser	yolov6/data/vis_dataset.py	/^    parser = argparse.ArgumentParser()$/;"	v
+parser	yolov6/data/voc2yolo.py	/^    parser = argparse.ArgumentParser()$/;"	v
+part_mAP	tools/partial_quantization/partial_quant.py	/^    part_mAP = yolov6_evaler.eval(model_ptq)$/;"	v
+partial_quant	tools/partial_quantization/ptq.py	/^def partial_quant(model_ptq, quantable_ops=None):$/;"	f
+pipeline	tools/quantization/ppq/ProgramEntrance.py	/^pipeline = PFL.Pipeline([$/;"	v
+plot	yolov6/utils/metrics.py	/^    def plot(self, normalize=True, save_dir='', names=()):$/;"	m	class:ConfusionMatrix
+plot_box_and_label	yolov6/core/inferer.py	/^    def plot_box_and_label(image, lw, box, label='', color=(128, 128, 128), txt_color=(255, 255, 255), font=cv2.FONT_HERSHEY_COMPLEX):$/;"	m	class:Inferer
+plot_confusion_matrix	configs/experiment/yolov6n_with_eval_params.py	/^    plot_confusion_matrix=False$/;"	v
+plot_curve	configs/experiment/yolov6n_with_eval_params.py	/^    plot_curve=False,$/;"	v
+plot_mc_curve	yolov6/utils/metrics.py	/^def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence', ylabel='Metric'):$/;"	f
+plot_pr_curve	yolov6/utils/metrics.py	/^def plot_pr_curve(px, py, ap, save_dir='pr_curve.png', names=()):$/;"	f
+plot_train_batch	yolov6/core/engine.py	/^    def plot_train_batch(self, images, targets, max_size=1920, max_subplots=16):$/;"	m	class:Trainer
+plot_val_pred	yolov6/core/engine.py	/^    def plot_val_pred(self, vis_outputs, vis_paths, vis_conf=0.3, vis_max_box_num=5):$/;"	m	class:Trainer
+policy	tools/quantization/ppq/ProgramEntrance.py	/^    policy = QuantizationPolicy($/;"	v
+post_process	deploy/ONNX/OpenCV/yolo.py	/^def post_process(input_image, outputs):$/;"	f
+post_process	deploy/ONNX/OpenCV/yolo_video.py	/^def post_process(input_image, outputs):$/;"	f
+post_process	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^Mat post_process(Mat &input_image, vector<Mat> &outputs, const vector<string> &class_name)$/;"	f
+post_process	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^Mat post_process(Mat &input_image, vector<Mat> &outputs, const vector<string> &class_name)$/;"	f
+post_process	deploy/TensorRT/Processor.py	/^    def post_process(self, outputs, img_shape, conf_thres=0.5, iou_thres=0.6):$/;"	m	class:Processor
+post_process	deploy/TensorRT/tensorrt_processor.py	/^    def post_process(self, outputs, img_shape, conf_thres=0.5, iou_thres=0.6):$/;"	m	class:Processor
+pre_process	deploy/ONNX/OpenCV/yolo.py	/^def pre_process(input_image, net):$/;"	f
+pre_process	deploy/ONNX/OpenCV/yolo_video.py	/^def pre_process(input_image, net):$/;"	f
+pre_process	deploy/ONNX/OpenCV/yolov5/yolov5.cpp	/^vector<Mat> pre_process(Mat &input_image, Net &net)$/;"	f
+pre_process	deploy/ONNX/OpenCV/yolov6/yolov6.cpp	/^vector<Mat> pre_process(Mat &input_image, Net &net)$/;"	f
+pre_process	deploy/TensorRT/Processor.py	/^    def pre_process(self, img_src, input_shape=None,):$/;"	m	class:Processor
+pre_process	deploy/TensorRT/tensorrt_processor.py	/^    def pre_process(self, img_src, input_shape=None,):$/;"	m	class:Processor
+predict	hubconf.py	/^    def predict(self, img_path):$/;"	m	class:Detector
+predict_model	yolov6/core/evaler.py	/^    def predict_model(self, model, dataloader, task):$/;"	m	class:Evaler
+prepro_data	yolov6/core/engine.py	/^    def prepro_data(batch_data, device):$/;"	m	class:Trainer
+preprocess	deploy/ONNX/OpenCV/yolox.py	/^    def preprocess(self, image):$/;"	m	class:yolox
+preprocess	yolov6/models/losses/loss.py	/^    def preprocess(self, targets, batch_size, scale_tensor):$/;"	m	class:ComputeLoss
+preprocess	yolov6/models/losses/loss_distill.py	/^    def preprocess(self, targets, batch_size, scale_tensor):$/;"	m	class:ComputeLoss
+preprocess	yolov6/models/losses/loss_distill_ns.py	/^    def preprocess(self, targets, batch_size, scale_tensor):$/;"	m	class:ComputeLoss
+preprocess	yolov6/models/losses/loss_fuseab.py	/^    def preprocess(self, targets, batch_size, scale_tensor):$/;"	m	class:ComputeLoss
+preprocess_yolov6	tools/quantization/tensorrt/post_training/Calibrator.py	/^def preprocess_yolov6(image, channels=3, height=224, width=224):$/;"	f
+pretrained	configs/base/yolov6l_base.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6l_base_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6m_base.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6m_base_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6n_base.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6n_base_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6s_base.py	/^    pretrained=None,$/;"	v
+pretrained	configs/base/yolov6s_base_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/experiment/yolov6n_with_eval_params.py	/^    pretrained=None,$/;"	v
+pretrained	configs/experiment/yolov6s_csp_scaled.py	/^    pretrained=None,$/;"	v
+pretrained	configs/experiment/yolov6t.py	/^    pretrained=None,$/;"	v
+pretrained	configs/experiment/yolov6t_csp_scaled.py	/^    pretrained=None,$/;"	v
+pretrained	configs/experiment/yolov6t_finetune.py	/^    pretrained='weights\/yolov6t.pt',$/;"	v
+pretrained	configs/mbla/yolov6l_mbla.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6l_mbla_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6m_mbla.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6m_mbla_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6s_mbla.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6s_mbla_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6x_mbla.py	/^    pretrained=None,$/;"	v
+pretrained	configs/mbla/yolov6x_mbla_finetune.py	/^    pretrained=None,$/;"	v
+pretrained	configs/qarepvgg/yolov6m_qa.py	/^    pretrained=None,$/;"	v
+pretrained	configs/qarepvgg/yolov6n_qa.py	/^    pretrained=None,$/;"	v
+pretrained	configs/qarepvgg/yolov6s_qa.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6_tiny_hs.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6_tiny_opt.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6_tiny_opt_qat.py	/^    pretrained='.\/assets\/v6s_t.pt',$/;"	v
+pretrained	configs/repopt/yolov6n_hs.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6n_opt.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6n_opt_qat.py	/^    pretrained='.\/assets\/v6s_n.pt',$/;"	v
+pretrained	configs/repopt/yolov6s_hs.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6s_opt.py	/^    pretrained=None,$/;"	v
+pretrained	configs/repopt/yolov6s_opt_qat.py	/^    pretrained='.\/assets\/yolov6s_v2_reopt_43.1.pt',$/;"	v
+pretrained	configs/yolov6_lite/yolov6_lite_l.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    pretrained='weights\/yolov6lite_l.pt',$/;"	v
+pretrained	configs/yolov6_lite/yolov6_lite_m.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    pretrained='weights\/yolov6lite_m.pt',$/;"	v
+pretrained	configs/yolov6_lite/yolov6_lite_s.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    pretrained='weights\/yolov6lite_s.pt',$/;"	v
+pretrained	configs/yolov6l.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6l6.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6l6_finetune.py	/^    pretrained='weights\/yolov6l6.pt',$/;"	v
+pretrained	configs/yolov6l_finetune.py	/^    pretrained='weights\/yolov6l.pt',$/;"	v
+pretrained	configs/yolov6m.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6m6.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6m6_finetune.py	/^    pretrained='weights\/yolov6m6.pt',$/;"	v
+pretrained	configs/yolov6m_finetune.py	/^    pretrained='weights\/yolov6m.pt',$/;"	v
+pretrained	configs/yolov6n.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6n6.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6n6_finetune.py	/^    pretrained='weights\/yolov6n6.pt',$/;"	v
+pretrained	configs/yolov6n_finetune.py	/^    pretrained='weights\/yolov6n.pt',$/;"	v
+pretrained	configs/yolov6s.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6s6.py	/^    pretrained=None,$/;"	v
+pretrained	configs/yolov6s6_finetune.py	/^    pretrained='weights\/yolov6s6.pt',$/;"	v
+pretrained	configs/yolov6s_finetune.py	/^    pretrained='weights\/yolov6s.pt',$/;"	v
+print	yolov6/utils/metrics.py	/^    def print(self):$/;"	m	class:ConfusionMatrix
+print_details	yolov6/core/engine.py	/^    def print_details(self):$/;"	m	class:Trainer
+prob	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    float prob;$/;"	m	struct:Object
+prob	deploy/TensorRT/yolov6.cpp	/^    float prob;$/;"	m	struct:Object	file:
+prob_threshold	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	float prob_threshold;$/;"	m	class:yolox	file:
+process_batch	yolov6/utils/metrics.py	/^    def process_batch(self, detections, labels):$/;"	m	class:ConfusionMatrix
+process_batch	yolov6/utils/metrics.py	/^def process_batch(detections, labels, iouv):$/;"	f
+process_image	deploy/TensorRT/calibrator.py	/^def process_image(img_src, img_size, stride):$/;"	f
+process_image	hubconf.py	/^def process_image(path, img_size, stride):$/;"	f
+process_image	yolov6/core/inferer.py	/^    def process_image(img_src, img_size, stride, half):$/;"	m	class:Inferer
+ptq	configs/repopt/yolov6_tiny_opt_qat.py	/^ptq = dict($/;"	v
+ptq	configs/repopt/yolov6n_opt_qat.py	/^ptq = dict($/;"	v
+ptq	configs/repopt/yolov6s_opt_qat.py	/^ptq = dict($/;"	v
+ptq_calibrate	tools/qat/qat_utils.py	/^def ptq_calibrate(model, train_loader, cfg):$/;"	f
+putOutput	deploy/TensorRT/logging.h	/^    void putOutput()$/;"	f	class:LogStreamConsumerBuffer
+qat	configs/repopt/yolov6_tiny_opt_qat.py	/^qat = dict($/;"	v
+qat	configs/repopt/yolov6n_opt_qat.py	/^qat = dict($/;"	v
+qat	configs/repopt/yolov6s_opt_qat.py	/^qat = dict($/;"	v
+qat_init_model_manu	tools/qat/qat_utils.py	/^def qat_init_model_manu(model, cfg, args):$/;"	f
+qat_mAP	tools/qat/qat_export.py	/^    qat_mAP = yolov6_evaler.eval(model)$/;"	v
+qfile	tools/partial_quantization/sensitivity_analyse.py	/^    qfile = "{}_quant_sensitivity_{}_calib.txt".format(os.path.basename(args.weights).split('.')[0],$/;"	v
+qsort_descent_inplace	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static void qsort_descent_inplace(std::vector<Object>& faceobjects)$/;"	f	file:
+qsort_descent_inplace	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static void qsort_descent_inplace(std::vector<Object>& faceobjects, int left, int right)$/;"	f	file:
+qsort_descent_inplace	deploy/TensorRT/yolov6.cpp	/^static void qsort_descent_inplace(std::vector<Object>& faceobjects, int left, int right)$/;"	f	file:
+qsort_descent_inplace	deploy/TensorRT/yolov6.cpp	/^static void qsort_descent_inplace(std::vector<Object>& objects)$/;"	f	file:
+quant_mAP	tools/partial_quantization/sensitivity_analyse.py	/^    quant_mAP = yolov6_evaler.eval(model_ptq)$/;"	v
+quant_model_init	tools/partial_quantization/ptq.py	/^def quant_model_init(model, device):$/;"	f
+quant_sensitivity	tools/partial_quantization/partial_quant.py	/^    quant_sensitivity = quant_sensitivity_load(args.sensitivity_file)$/;"	v
+quant_sensitivity	tools/partial_quantization/sensitivity_analyse.py	/^    quant_sensitivity = quant_sensitivity_analyse(model_ptq, yolov6_evaler)$/;"	v
+quant_sensitivity_analyse	tools/partial_quantization/sensitivity_analyse.py	/^def quant_sensitivity_analyse(model_ptq, evaler):$/;"	f
+quant_sensitivity_load	tools/partial_quantization/utils.py	/^def quant_sensitivity_load(file):$/;"	f
+quant_sensitivity_save	tools/partial_quantization/utils.py	/^def quant_sensitivity_save(quant_sensitivity, file):$/;"	f
+quant_setup	yolov6/core/engine.py	/^    def quant_setup(self, model, cfg, device):$/;"	m	class:Trainer
+quant_types	tools/quantization/ppq/ProgramEntrance.py	/^    quant_types=quantizer.quant_operation_types)$/;"	v
+quantable_op_check	tools/partial_quantization/ptq.py	/^def quantable_op_check(k, quantable_ops):$/;"	f
+quantable_ops	tools/partial_quantization/partial_quant.py	/^    quantable_ops = [qops[0] for qops in quant_sensitivity[:boundary+1]]$/;"	v
+quantizer	tools/quantization/ppq/ProgramEntrance.py	/^quantizer = PFL.Quantizer(platform=TargetPlatform.TRT_INT8, graph=graph) # 取得 TRT_INT8 所对应的量化器$/;"	v
+random_affine	yolov6/data/data_augment.py	/^def random_affine(img, labels=(), degrees=10, translate=.1, scale=.1, shear=10,$/;"	f
+read_calibration_cache	deploy/TensorRT/calibrator.py	/^    def read_calibration_cache(self):$/;"	m	class:Calibrator
+read_calibration_cache	tools/quantization/tensorrt/post_training/Calibrator.py	/^    def read_calibration_cache(self):$/;"	m	class:ImageCalibrator
+rect	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    cv::Rect_<float> rect;$/;"	m	struct:Object
+rect	deploy/TensorRT/yolov6.cpp	/^    cv::Rect_<float> rect;$/;"	m	struct:Object	file:
+reg_max	configs/base/yolov6l_base.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/base/yolov6l_base_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/base/yolov6m_base.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/base/yolov6m_base_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/base/yolov6n_base.py	/^        reg_max=16, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/base/yolov6n_base_finetune.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/base/yolov6s_base.py	/^        reg_max=16, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/base/yolov6s_base_finetune.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/experiment/yolov6n_with_eval_params.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/experiment/yolov6s_csp_scaled.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/experiment/yolov6t.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/experiment/yolov6t_csp_scaled.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/experiment/yolov6t_finetune.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6l_mbla.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6l_mbla_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6m_mbla.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6m_mbla_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6s_mbla.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6s_mbla_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6x_mbla.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/mbla/yolov6x_mbla_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/qarepvgg/yolov6m_qa.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/qarepvgg/yolov6n_qa.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/qarepvgg/yolov6s_qa.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/repopt/yolov6_tiny_hs.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/repopt/yolov6_tiny_opt.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/repopt/yolov6_tiny_opt_qat.py	/^        reg_max=0, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/repopt/yolov6n_hs.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/repopt/yolov6n_opt.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/repopt/yolov6n_opt_qat.py	/^        reg_max=0, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/repopt/yolov6s_hs.py	/^        reg_max=0$/;"	v
+reg_max	configs/repopt/yolov6s_opt.py	/^        reg_max=0$/;"	v
+reg_max	configs/repopt/yolov6s_opt_qat.py	/^        reg_max = 0,  # if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6_lite/yolov6_lite_l.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6_lite/yolov6_lite_m.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6_lite/yolov6_lite_s.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6l.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6l6.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6l6_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6l_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6m.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6m6.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6m6_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6m_finetune.py	/^        reg_max=16, #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6n.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/yolov6n6.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6n6_finetune.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6n_finetune.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/yolov6s.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reg_max	configs/yolov6s6.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6s6_finetune.py	/^        reg_max=0 #if use_dfl is False, please set reg_max to 0$/;"	v
+reg_max	configs/yolov6s_finetune.py	/^        reg_max=0, # set to 16 if you want to further train with distillation$/;"	v
+reinitialize	yolov6/utils/RepOptimizer.py	/^    def reinitialize(self, scales_by_idx, conv3x3_by_idx, use_identity_scales):$/;"	m	class:RepVGGOptimizer
+reload	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private void reload()$/;"	m	class:MainActivity	file:
+reload_dataset	yolov6/core/evaler.py	/^    def reload_dataset(data, task='val'):$/;"	m	class:Evaler
+reload_device	yolov6/core/evaler.py	/^    def reload_device(device, model, task):$/;"	m	class:Evaler
+reportFail	deploy/TensorRT/logging.h	/^    static int reportFail(const TestAtom& testAtom)$/;"	f	class:Logger
+reportPass	deploy/TensorRT/logging.h	/^    static int reportPass(const TestAtom& testAtom)$/;"	f	class:Logger
+reportTest	deploy/TensorRT/logging.h	/^    static int reportTest(const TestAtom& testAtom, bool pass)$/;"	f	class:Logger
+reportTestEnd	deploy/TensorRT/logging.h	/^    static void reportTestEnd(const TestAtom& testAtom, TestResult result)$/;"	f	class:Logger
+reportTestResult	deploy/TensorRT/logging.h	/^    static void reportTestResult(const TestAtom& testAtom, TestResult result)$/;"	f	class:Logger
+reportTestStart	deploy/TensorRT/logging.h	/^    static void reportTestStart(TestAtom& testAtom)$/;"	f	class:Logger
+reportWaive	deploy/TensorRT/logging.h	/^    static int reportWaive(const TestAtom& testAtom)$/;"	f	class:Logger
+rescale	yolov6/core/inferer.py	/^    def rescale(ori_shape, boxes, target_shape):$/;"	m	class:Inferer
+reset	deploy/TensorRT/calibrator.py	/^    def reset(self):$/;"	m	class:DataLoader
+resize_image	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^Mat yolox::resize_image(Mat srcimg, float* scale)$/;"	f	class:yolox
+rounding	tools/quantization/ppq/ProgramEntrance.py	/^    rounding=RoundingPolicy.ROUND_HALF_EVEN,$/;"	v
+run	deploy/ONNX/eval_trt.py	/^def run(data,$/;"	f
+run	tools/eval.py	/^def run(data,$/;"	f
+run	tools/infer.py	/^def run(weights=osp.join(ROOT, 'yolov6s.pt'),$/;"	f
+save_calib_cache_file	tools/qat/onnx_utils.py	/^def save_calib_cache_file(cache_file, activation_map, headline='TRT-8XXX-EntropyCalibration2\\n'):$/;"	f
+save_calib_model	yolov6/core/engine.py	/^        def save_calib_model(model, cfg):$/;"	f	function:Trainer.calibrate
+save_checkpoint	yolov6/utils/checkpoint.py	/^def save_checkpoint(ckpt, is_best, save_dir, model_name=""):$/;"	f
+save_yaml	yolov6/utils/events.py	/^def save_yaml(data_dict, save_path):$/;"	f
+scale	configs/base/yolov6l_base.py	/^    scale=0.9,$/;"	v
+scale	configs/base/yolov6l_base_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/base/yolov6m_base.py	/^    scale=0.9,$/;"	v
+scale	configs/base/yolov6m_base_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/base/yolov6n_base.py	/^    scale=0.5,$/;"	v
+scale	configs/base/yolov6n_base_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/base/yolov6s_base.py	/^    scale=0.5,$/;"	v
+scale	configs/base/yolov6s_base_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/experiment/yolov6n_with_eval_params.py	/^    scale=0.5,$/;"	v
+scale	configs/experiment/yolov6s_csp_scaled.py	/^    scale=0.9,$/;"	v
+scale	configs/experiment/yolov6t.py	/^    scale=0.5,$/;"	v
+scale	configs/experiment/yolov6t_csp_scaled.py	/^    scale=0.9,$/;"	v
+scale	configs/experiment/yolov6t_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/mbla/yolov6l_mbla.py	/^    scale=0.9,$/;"	v
+scale	configs/mbla/yolov6l_mbla_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/mbla/yolov6m_mbla.py	/^    scale=0.9,$/;"	v
+scale	configs/mbla/yolov6m_mbla_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/mbla/yolov6s_mbla.py	/^    scale=0.9,$/;"	v
+scale	configs/mbla/yolov6s_mbla_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/mbla/yolov6x_mbla.py	/^    scale=0.9,$/;"	v
+scale	configs/mbla/yolov6x_mbla_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/qarepvgg/yolov6m_qa.py	/^    scale=0.9,$/;"	v
+scale	configs/qarepvgg/yolov6n_qa.py	/^    scale=0.5,$/;"	v
+scale	configs/qarepvgg/yolov6s_qa.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6_tiny_hs.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6_tiny_opt.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6_tiny_opt_qat.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6n_hs.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6n_opt.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6n_opt_qat.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6s_hs.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6s_opt.py	/^    scale=0.5,$/;"	v
+scale	configs/repopt/yolov6s_opt_qat.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6_lite/yolov6_lite_l.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6_lite/yolov6_lite_m.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6_lite/yolov6_lite_s.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6l.py	/^    scale=0.9,$/;"	v
+scale	configs/yolov6l6.py	/^    scale=0.9,$/;"	v
+scale	configs/yolov6l6_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6l_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6m.py	/^    scale=0.9,$/;"	v
+scale	configs/yolov6m6.py	/^    scale=0.9,$/;"	v
+scale	configs/yolov6m6_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6m_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6n.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6n6.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6n6_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6n_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6s.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6s6.py	/^    scale=0.5,$/;"	v
+scale	configs/yolov6s6_finetune.py	/^    scale=0.898,$/;"	v
+scale	configs/yolov6s_finetune.py	/^    scale=0.898,$/;"	v
+scale_coords	deploy/TensorRT/Processor.py	/^    def scale_coords(self, img1_shape, coords, img0_shape, ratio_pad=None):$/;"	m	class:Processor
+scale_coords	deploy/TensorRT/eval_yolo_trt.py	/^def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None):$/;"	f
+scale_coords	deploy/TensorRT/tensorrt_processor.py	/^    def scale_coords(self, img1_shape, coords, img0_shape, ratio_pad=None):$/;"	m	class:Processor
+scale_coords	yolov6/core/evaler.py	/^    def scale_coords(self, img1_shape, coords, img0_shape, ratio_pad=None):$/;"	m	class:Evaler
+scale_size	configs/yolov6_lite/yolov6_lite_l.py	/^        scale_size=0.5,$/;"	v
+scale_size	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        scale_size=0.5,$/;"	v
+scale_size	configs/yolov6_lite/yolov6_lite_m.py	/^        scale_size=0.5,$/;"	v
+scale_size	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        scale_size=0.5,$/;"	v
+scale_size	configs/yolov6_lite/yolov6_lite_s.py	/^        scale_size=0.5,$/;"	v
+scale_size	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        scale_size=0.5,$/;"	v
+scales	configs/repopt/yolov6_tiny_opt.py	/^    scales='..\/yolov6_assert\/v6t_v2_scale_last.pt',$/;"	v
+scales	configs/repopt/yolov6_tiny_opt_qat.py	/^    scales='.\/assets\/v6t_v2_scale_last.pt',$/;"	v
+scales	configs/repopt/yolov6n_opt.py	/^    scales='..\/yolov6_assert\/v6n_v2_scale_last.pt',$/;"	v
+scales	configs/repopt/yolov6n_opt_qat.py	/^    scales='.\/assets\/v6n_v2_scale_last.pt',$/;"	v
+scales	configs/repopt/yolov6s_opt.py	/^    scales='..\/yolov6_assert\/v6s_v2_scale.pt',$/;"	v
+scales	configs/repopt/yolov6s_opt_qat.py	/^    scales='.\/assets\/yolov6s_v2_scale.pt',$/;"	v
+search_node_by_output_id	tools/qat/onnx_utils.py	/^def search_node_by_output_id(nodes, output_id: str):$/;"	f
+select_candidates_in_gts	yolov6/assigners/assigner_utils.py	/^def select_candidates_in_gts(xy_centers, gt_bboxes, eps=1e-9):$/;"	f
+select_device	yolov6/utils/envs.py	/^def select_device(device):$/;"	f
+select_highest_overlaps	yolov6/assigners/assigner_utils.py	/^def select_highest_overlaps(mask_pos, overlaps, n_max_boxes):$/;"	f
+select_topk_candidates	yolov6/assigners/atss_assigner.py	/^    def select_topk_candidates(self,$/;"	m	class:ATSSAssigner
+select_topk_candidates	yolov6/assigners/tal_assigner.py	/^    def select_topk_candidates(self,$/;"	m	class:TaskAlignedAssigner
+sensitive_layers_list	configs/repopt/yolov6_tiny_opt_qat.py	/^    sensitive_layers_list=[],$/;"	v
+sensitive_layers_list	configs/repopt/yolov6n_opt_qat.py	/^    sensitive_layers_list=[],$/;"	v
+sensitive_layers_list	configs/repopt/yolov6s_opt_qat.py	/^    sensitive_layers_list=['detect.stems.0.conv',$/;"	v
+sensitive_layers_skip	configs/repopt/yolov6_tiny_opt_qat.py	/^    sensitive_layers_skip = False,$/;"	v
+sensitive_layers_skip	configs/repopt/yolov6_tiny_opt_qat.py	/^    sensitive_layers_skip=False,$/;"	v
+sensitive_layers_skip	configs/repopt/yolov6n_opt_qat.py	/^    sensitive_layers_skip = False,$/;"	v
+sensitive_layers_skip	configs/repopt/yolov6n_opt_qat.py	/^    sensitive_layers_skip=False,$/;"	v
+sensitive_layers_skip	configs/repopt/yolov6s_opt_qat.py	/^    sensitive_layers_skip = False,$/;"	v
+sensitive_layers_skip	configs/repopt/yolov6s_opt_qat.py	/^    sensitive_layers_skip=False,$/;"	v
+sensor_event_queue	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    mutable ASensorEventQueue* sensor_event_queue;$/;"	m	class:NdkCameraWindow
+sensor_manager	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ASensorManager* sensor_manager;$/;"	m	class:NdkCameraWindow
+setDynamicRange	tools/quantization/ppq/write_qparams_onnx2trt.py	/^def setDynamicRange(network, json_file):$/;"	f
+setOutputWindow	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/Yolov6Ncnn.java	/^    public native boolean setOutputWindow(Surface surface);$/;"	m	class:Yolov6Ncnn
+setReportableSeverity	deploy/TensorRT/logging.h	/^    void setReportableSeverity(Severity reportableSeverity)$/;"	f	class:LogStreamConsumer
+setReportableSeverity	deploy/TensorRT/logging.h	/^    void setReportableSeverity(Severity severity)$/;"	f	class:Logger
+setShouldLog	deploy/TensorRT/logging.h	/^    void setShouldLog(bool shouldLog)$/;"	f	class:LogStreamConsumerBuffer
+set_logging	yolov6/utils/events.py	/^def set_logging(name=None):$/;"	f
+set_module	tools/partial_quantization/utils.py	/^def set_module(model, submodule_key, module):$/;"	f
+set_random_seed	yolov6/utils/envs.py	/^def set_random_seed(seed, deterministic=False):$/;"	f
+set_weight_decay	yolov6/utils/RepOptimizer.py	/^def set_weight_decay(model, skip_list=(), skip_keywords=(), echo=False):$/;"	f
+set_window	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^void NdkCameraWindow::set_window(ANativeWindow* _win)$/;"	f	class:NdkCameraWindow
+severityOstream	deploy/TensorRT/logging.h	/^    static std::ostream& severityOstream(Severity severity)$/;"	f	class:LogStreamConsumer
+severityOstream	deploy/TensorRT/logging.h	/^    static std::ostream& severityOstream(Severity severity)$/;"	f	class:Logger
+severityPrefix	deploy/TensorRT/logging.h	/^    static const char* severityPrefix(Severity severity)$/;"	f	class:Logger
+severityPrefix	deploy/TensorRT/logging.h	/^    static std::string severityPrefix(Severity severity)$/;"	f	class:LogStreamConsumer
+shapes	deploy/ONNX/export_onnx.py	/^                shapes = [args.batch_size, 1, args.batch_size, args.topk_all, 4,$/;"	v
+shear	configs/base/yolov6l_base.py	/^    shear=0.0,$/;"	v
+shear	configs/base/yolov6l_base_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/base/yolov6m_base.py	/^    shear=0.0,$/;"	v
+shear	configs/base/yolov6m_base_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/base/yolov6n_base.py	/^    shear=0.0,$/;"	v
+shear	configs/base/yolov6n_base_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/base/yolov6s_base.py	/^    shear=0.0,$/;"	v
+shear	configs/base/yolov6s_base_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/experiment/yolov6n_with_eval_params.py	/^    shear=0.0,$/;"	v
+shear	configs/experiment/yolov6s_csp_scaled.py	/^    shear=0.0,$/;"	v
+shear	configs/experiment/yolov6t.py	/^    shear=0.0,$/;"	v
+shear	configs/experiment/yolov6t_csp_scaled.py	/^    shear=0.0,$/;"	v
+shear	configs/experiment/yolov6t_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/mbla/yolov6l_mbla.py	/^    shear=0.0,$/;"	v
+shear	configs/mbla/yolov6l_mbla_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/mbla/yolov6m_mbla.py	/^    shear=0.0,$/;"	v
+shear	configs/mbla/yolov6m_mbla_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/mbla/yolov6s_mbla.py	/^    shear=0.0,$/;"	v
+shear	configs/mbla/yolov6s_mbla_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/mbla/yolov6x_mbla.py	/^    shear=0.0,$/;"	v
+shear	configs/mbla/yolov6x_mbla_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/qarepvgg/yolov6m_qa.py	/^    shear=0.0,$/;"	v
+shear	configs/qarepvgg/yolov6n_qa.py	/^    shear=0.0,$/;"	v
+shear	configs/qarepvgg/yolov6s_qa.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6_tiny_hs.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6_tiny_opt.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6_tiny_opt_qat.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6n_hs.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6n_opt.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6n_opt_qat.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6s_hs.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6s_opt.py	/^    shear=0.0,$/;"	v
+shear	configs/repopt/yolov6s_opt_qat.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6_lite/yolov6_lite_l.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6_lite/yolov6_lite_m.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6_lite/yolov6_lite_s.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6l.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6l6.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6l6_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6l_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6m.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6m6.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6m6_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6m_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6n.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6n6.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6n6_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6n_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6s.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6s6.py	/^    shear=0.0,$/;"	v
+shear	configs/yolov6s6_finetune.py	/^    shear=0.602,$/;"	v
+shear	configs/yolov6s_finetune.py	/^    shear=0.602,$/;"	v
+show_predict	hubconf.py	/^    def show_predict(self,$/;"	m	class:Detector
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=17,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=2,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=3,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=4,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=41,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=6,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=64,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=7,$/;"	v
+shrink_size	configs/experiment/eval_640_repro.py	/^        shrink_size=8,$/;"	v
+shrink_size	configs/experiment/yolov6n_with_eval_params.py	/^    shrink_size=None, # None mean will not shrink the image.$/;"	v
+shuffle	tools/partial_quantization/sensitivity_analyse.py	/^        shuffle=True,$/;"	v
+sigmoid	deploy/NCNN/Android/app/src/main/jni/yolo.cpp	/^static float sigmoid(float x)$/;"	f	file:
+sigmoid	deploy/NCNN/infer-ncnn-model.py	/^def sigmoid(x: ndarray) -> ndarray:$/;"	f
+skip_sensitive_layers	tools/qat/qat_utils.py	/^def skip_sensitive_layers(model, sensitive_layers):$/;"	f
+softmax	deploy/NCNN/infer-ncnn-model.py	/^def softmax(x: ndarray, axis: int = -1) -> ndarray:$/;"	f
+solver	configs/base/yolov6l_base.py	/^solver=dict($/;"	v
+solver	configs/base/yolov6l_base_finetune.py	/^solver = dict($/;"	v
+solver	configs/base/yolov6m_base.py	/^solver=dict($/;"	v
+solver	configs/base/yolov6m_base_finetune.py	/^solver = dict($/;"	v
+solver	configs/base/yolov6n_base.py	/^solver = dict($/;"	v
+solver	configs/base/yolov6n_base_finetune.py	/^solver = dict($/;"	v
+solver	configs/base/yolov6s_base.py	/^solver = dict($/;"	v
+solver	configs/base/yolov6s_base_finetune.py	/^solver = dict($/;"	v
+solver	configs/experiment/yolov6n_with_eval_params.py	/^solver = dict($/;"	v
+solver	configs/experiment/yolov6s_csp_scaled.py	/^solver=dict($/;"	v
+solver	configs/experiment/yolov6t.py	/^solver = dict($/;"	v
+solver	configs/experiment/yolov6t_csp_scaled.py	/^solver=dict($/;"	v
+solver	configs/experiment/yolov6t_finetune.py	/^solver = dict($/;"	v
+solver	configs/mbla/yolov6l_mbla.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6l_mbla_finetune.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6m_mbla.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6m_mbla_finetune.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6s_mbla.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6s_mbla_finetune.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6x_mbla.py	/^solver=dict($/;"	v
+solver	configs/mbla/yolov6x_mbla_finetune.py	/^solver=dict($/;"	v
+solver	configs/qarepvgg/yolov6m_qa.py	/^solver=dict($/;"	v
+solver	configs/qarepvgg/yolov6n_qa.py	/^solver = dict($/;"	v
+solver	configs/qarepvgg/yolov6s_qa.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6_tiny_hs.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6_tiny_opt.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6_tiny_opt_qat.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6n_hs.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6n_opt.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6n_opt_qat.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6s_hs.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6s_opt.py	/^solver = dict($/;"	v
+solver	configs/repopt/yolov6s_opt_qat.py	/^solver = dict($/;"	v
+solver	configs/yolov6_lite/yolov6_lite_l.py	/^solver = dict($/;"	v
+solver	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6_lite/yolov6_lite_m.py	/^solver = dict($/;"	v
+solver	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6_lite/yolov6_lite_s.py	/^solver = dict($/;"	v
+solver	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6l.py	/^solver=dict($/;"	v
+solver	configs/yolov6l6.py	/^solver = dict($/;"	v
+solver	configs/yolov6l6_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6l_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6m.py	/^solver=dict($/;"	v
+solver	configs/yolov6m6.py	/^solver = dict($/;"	v
+solver	configs/yolov6m6_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6m_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6n.py	/^solver = dict($/;"	v
+solver	configs/yolov6n6.py	/^solver = dict($/;"	v
+solver	configs/yolov6n6_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6n_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6s.py	/^solver = dict($/;"	v
+solver	configs/yolov6s6.py	/^solver = dict($/;"	v
+solver	configs/yolov6s6_finetune.py	/^solver = dict($/;"	v
+solver	configs/yolov6s_finetune.py	/^solver = dict($/;"	v
+sort_files_shapes	yolov6/data/datasets.py	/^    def sort_files_shapes(self):$/;"	m	class:TrainValDataset
+spinnerCPUGPU	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private Spinner spinnerCPUGPU;$/;"	f	class:MainActivity	file:
+spinnerModel	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private Spinner spinnerModel;$/;"	f	class:MainActivity	file:
+srcimg	deploy/ONNX/OpenCV/yolox.py	/^    srcimg = cv2.imread(args.img)$/;"	v	class:yolox
+stage_block_type	configs/mbla/yolov6l_mbla.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6l_mbla_finetune.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6m_mbla.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6m_mbla_finetune.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6s_mbla.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6s_mbla_finetune.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6x_mbla.py	/^        stage_block_type="MBLABlock",$/;"	v
+stage_block_type	configs/mbla/yolov6x_mbla_finetune.py	/^        stage_block_type="MBLABlock",$/;"	v
+static_resize	deploy/TensorRT/yolov6.cpp	/^cv::Mat static_resize(cv::Mat& img) {$/;"	f
+std	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	const float std[3] = { 0.229, 0.224, 0.225 };$/;"	m	class:yolox	file:
+step	yolov6/utils/RepOptimizer.py	/^    def step(self, closure=None):$/;"	m	class:RepVGGOptimizer
+stride	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^	const int stride[3] = { 8, 16, 32 };$/;"	m	class:yolox	file:
+stride	tools/partial_quantization/sensitivity_analyse.py	/^        stride=32,$/;"	v
+strides	configs/base/yolov6l_base.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6l_base_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6m_base.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6m_base_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6n_base.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6n_base_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6s_base.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/base/yolov6s_base_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/experiment/yolov6n_with_eval_params.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/experiment/yolov6s_csp_scaled.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/experiment/yolov6t.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/experiment/yolov6t_csp_scaled.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/experiment/yolov6t_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6l_mbla.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6l_mbla_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6m_mbla.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6m_mbla_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6s_mbla.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6s_mbla_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6x_mbla.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/mbla/yolov6x_mbla_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/qarepvgg/yolov6m_qa.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/qarepvgg/yolov6n_qa.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/qarepvgg/yolov6s_qa.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6_tiny_hs.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6_tiny_opt.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6_tiny_opt_qat.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6n_hs.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6n_opt.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6n_opt_qat.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6s_hs.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6s_opt.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/repopt/yolov6s_opt_qat.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6_lite/yolov6_lite_l.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6_lite/yolov6_lite_m.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6_lite/yolov6_lite_s.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6l.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6l6.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6l6_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6l_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6m.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6m6.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6m6_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6m_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6n.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6n6.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6n6_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6n_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6s.py	/^        strides=[8, 16, 32],$/;"	v
+strides	configs/yolov6s6.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6s6_finetune.py	/^        strides=[8, 16, 32, 64],$/;"	v
+strides	configs/yolov6s_finetune.py	/^        strides=[8, 16, 32],$/;"	v
+strip_model	yolov6/core/engine.py	/^    def strip_model(self):$/;"	m	class:Trainer
+strip_optimizer	yolov6/utils/checkpoint.py	/^def strip_optimizer(ckpt_dir, epoch):$/;"	f
+surfaceChanged	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height)$/;"	m	class:MainActivity
+surfaceCreated	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public void surfaceCreated(SurfaceHolder holder)$/;"	m	class:MainActivity
+surfaceDestroyed	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    public void surfaceDestroyed(SurfaceHolder holder)$/;"	m	class:MainActivity
+switch_to_deploy	yolov6/layers/common.py	/^    def switch_to_deploy(self):$/;"	m	class:QARepVGGBlock
+switch_to_deploy	yolov6/layers/common.py	/^    def switch_to_deploy(self):$/;"	m	class:QARepVGGBlockV2
+switch_to_deploy	yolov6/layers/common.py	/^    def switch_to_deploy(self):$/;"	m	class:RepVGGBlock
+symbolic	yolov6/models/end2end.py	/^    def symbolic(g, boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold):$/;"	m	class:ORT_NMS
+symbolic	yolov6/models/end2end.py	/^    def symbolic(g,$/;"	m	class:TRT7_NMS
+symbolic	yolov6/models/end2end.py	/^    def symbolic(g,$/;"	m	class:TRT8_NMS
+sync	deploy/TensorRT/logging.h	/^    virtual int sync()$/;"	f	class:LogStreamConsumerBuffer
+t	deploy/NCNN/export_torchscript.py	/^    t = time.time()$/;"	v
+t	deploy/ONNX/export_onnx.py	/^    t = time.time()$/;"	v
+t	deploy/OpenVINO/export_openvino.py	/^    t = time.time()$/;"	v
+t	tools/partial_quantization/partial_quant.py	/^    t = time.time()$/;"	v
+t	tools/qat/qat_export.py	/^    t = time.time()$/;"	v
+tensorrt_official_qat	tools/quantization/tensorrt/training_aware/QAT_quantizer.py	/^def tensorrt_official_qat():$/;"	f
+testResultString	deploy/TensorRT/logging.h	/^    static const char* testResultString(TestResult result)$/;"	f	class:Logger
+text	yolov6/utils/config.py	/^    def text(self):$/;"	m	class:Config
+thop	yolov6/utils/torch_utils.py	/^    thop = None$/;"	v
+thres_calculator	yolov6/assigners/atss_assigner.py	/^    def thres_calculator(self,$/;"	m	class:ATSSAssigner
+time_sync	yolov6/utils/torch_utils.py	/^def time_sync():$/;"	f
+torch_1_10_plus	yolov6/assigners/anchor_generator.py	/^torch_1_10_plus = check_version(torch.__version__, minimum='1.10.0')$/;"	v
+torch_device_from_trt	deploy/TensorRT/Processor.py	/^def torch_device_from_trt(device):$/;"	f
+torch_device_from_trt	deploy/TensorRT/tensorrt_processor.py	/^def torch_device_from_trt(device):$/;"	f
+torch_distributed_zero_first	yolov6/utils/torch_utils.py	/^def torch_distributed_zero_first(local_rank: int):$/;"	f
+torch_dtype_from_trt	deploy/TensorRT/Processor.py	/^def torch_dtype_from_trt(dtype):$/;"	f
+torch_dtype_from_trt	deploy/TensorRT/tensorrt_processor.py	/^def torch_dtype_from_trt(dtype):$/;"	f
+total_time	deploy/ONNX/OpenCV/yolo.py	/^	total_time = 0$/;"	v
+total_time	deploy/ONNX/OpenCV/yolox.py	/^    total_time = 0$/;"	v	class:yolox
+tp_fp	yolov6/utils/metrics.py	/^    def tp_fp(self):$/;"	m	class:ConfusionMatrix
+trace_model	deploy/NCNN/export_torchscript.py	/^        trace_model = torch.jit.trace(model, img)$/;"	v
+train	yolov6/core/engine.py	/^    def train(self):$/;"	m	class:Trainer
+train_after_loop	yolov6/core/engine.py	/^    def train_after_loop(self):$/;"	m	class:Trainer
+train_in_steps	yolov6/core/engine.py	/^    def train_in_steps(self, epoch_num, step_num):$/;"	m	class:Trainer
+train_one_epoch	yolov6/core/engine.py	/^    def train_one_epoch(self, epoch_num):$/;"	m	class:Trainer
+training	deploy/ONNX/export_onnx.py	/^                              training=torch.onnx.TrainingMode.EVAL,$/;"	v
+training	deploy/OpenVINO/export_openvino.py	/^                          training=torch.onnx.TrainingMode.EVAL,$/;"	v
+training	tools/partial_quantization/partial_quant.py	/^                          training=torch.onnx.TrainingMode.EVAL,$/;"	v
+training	tools/qat/qat_export.py	/^                          training=torch.onnx.TrainingMode.EVAL,$/;"	v
+training_mode	configs/base/yolov6l_base.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6l_base_finetune.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6m_base.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6m_base_finetune.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6n_base.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6n_base_finetune.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6s_base.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/base/yolov6s_base_finetune.py	/^training_mode = "conv_relu"$/;"	v
+training_mode	configs/mbla/yolov6l_mbla.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6l_mbla_finetune.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6m_mbla.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6m_mbla_finetune.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6s_mbla.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6s_mbla_finetune.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6x_mbla.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/mbla/yolov6x_mbla_finetune.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/qarepvgg/yolov6m_qa.py	/^training_mode='qarepvggv2'$/;"	v
+training_mode	configs/qarepvgg/yolov6n_qa.py	/^training_mode='qarepvggv2'$/;"	v
+training_mode	configs/qarepvgg/yolov6s_qa.py	/^training_mode='qarepvggv2'$/;"	v
+training_mode	configs/repopt/yolov6_tiny_hs.py	/^training_mode='hyper_search'$/;"	v
+training_mode	configs/repopt/yolov6_tiny_opt.py	/^training_mode='repopt'$/;"	v
+training_mode	configs/repopt/yolov6_tiny_opt_qat.py	/^training_mode='repopt'$/;"	v
+training_mode	configs/repopt/yolov6n_hs.py	/^training_mode='hyper_search'$/;"	v
+training_mode	configs/repopt/yolov6n_opt.py	/^training_mode='repopt'$/;"	v
+training_mode	configs/repopt/yolov6n_opt_qat.py	/^training_mode='repopt'$/;"	v
+training_mode	configs/repopt/yolov6s_hs.py	/^training_mode='hyper_search'$/;"	v
+training_mode	configs/repopt/yolov6s_opt.py	/^training_mode='repopt'$/;"	v
+training_mode	configs/repopt/yolov6s_opt_qat.py	/^training_mode='repopt'$/;"	v
+training_mode	configs/yolov6l.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/yolov6l6.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/yolov6l6_finetune.py	/^training_mode = "conv_silu"$/;"	v
+training_mode	configs/yolov6l_finetune.py	/^training_mode = "conv_silu"$/;"	v
+transIII_1x1_kxk	yolov6/layers/dbb_transforms.py	/^def transIII_1x1_kxk(k1, b1, k2, b2, groups):$/;"	f
+transII_addbranch	yolov6/layers/dbb_transforms.py	/^def transII_addbranch(kernels, biases):$/;"	f
+transIV_depthconcat	yolov6/layers/dbb_transforms.py	/^def transIV_depthconcat(kernels, biases):$/;"	f
+transI_fusebn	yolov6/layers/dbb_transforms.py	/^def transI_fusebn(kernel, bn):$/;"	f
+transVI_multiscale	yolov6/layers/dbb_transforms.py	/^def transVI_multiscale(kernel, target_kernel_size):$/;"	f
+transV_avg	yolov6/layers/dbb_transforms.py	/^def transV_avg(channels, kernel_size, groups):$/;"	f
+translate	configs/base/yolov6l_base.py	/^    translate=0.1,$/;"	v
+translate	configs/base/yolov6l_base_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/base/yolov6m_base.py	/^    translate=0.1,$/;"	v
+translate	configs/base/yolov6m_base_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/base/yolov6n_base.py	/^    translate=0.1,$/;"	v
+translate	configs/base/yolov6n_base_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/base/yolov6s_base.py	/^    translate=0.1,$/;"	v
+translate	configs/base/yolov6s_base_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/experiment/yolov6n_with_eval_params.py	/^    translate=0.1,$/;"	v
+translate	configs/experiment/yolov6s_csp_scaled.py	/^    translate=0.1,$/;"	v
+translate	configs/experiment/yolov6t.py	/^    translate=0.1,$/;"	v
+translate	configs/experiment/yolov6t_csp_scaled.py	/^    translate=0.1,$/;"	v
+translate	configs/experiment/yolov6t_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/mbla/yolov6l_mbla.py	/^    translate=0.1,$/;"	v
+translate	configs/mbla/yolov6l_mbla_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/mbla/yolov6m_mbla.py	/^    translate=0.1,$/;"	v
+translate	configs/mbla/yolov6m_mbla_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/mbla/yolov6s_mbla.py	/^    translate=0.1,$/;"	v
+translate	configs/mbla/yolov6s_mbla_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/mbla/yolov6x_mbla.py	/^    translate=0.1,$/;"	v
+translate	configs/mbla/yolov6x_mbla_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/qarepvgg/yolov6m_qa.py	/^    translate=0.1,$/;"	v
+translate	configs/qarepvgg/yolov6n_qa.py	/^    translate=0.1,$/;"	v
+translate	configs/qarepvgg/yolov6s_qa.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6_tiny_hs.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6_tiny_opt.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6_tiny_opt_qat.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6n_hs.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6n_opt.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6n_opt_qat.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6s_hs.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6s_opt.py	/^    translate=0.1,$/;"	v
+translate	configs/repopt/yolov6s_opt_qat.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6_lite/yolov6_lite_l.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6_lite/yolov6_lite_m.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6_lite/yolov6_lite_s.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6l.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6l6.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6l6_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6l_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6m.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6m6.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6m6_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6m_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6n.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6n6.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6n6_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6n_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6s.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6s6.py	/^    translate=0.1,$/;"	v
+translate	configs/yolov6s6_finetune.py	/^    translate=0.245,$/;"	v
+translate	configs/yolov6s_finetune.py	/^    translate=0.245,$/;"	v
+type	configs/base/yolov6l_base.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/base/yolov6l_base.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/base/yolov6l_base.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6l_base.py	/^    type='YOLOv6l_base',$/;"	v
+type	configs/base/yolov6l_base_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/base/yolov6l_base_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/base/yolov6l_base_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6l_base_finetune.py	/^    type='YOLOv6l_base',$/;"	v
+type	configs/base/yolov6m_base.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/base/yolov6m_base.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/base/yolov6m_base.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6m_base.py	/^    type='YOLOv6m_base',$/;"	v
+type	configs/base/yolov6m_base_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/base/yolov6m_base_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/base/yolov6m_base_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6m_base_finetune.py	/^    type='YOLOv6m_base',$/;"	v
+type	configs/base/yolov6n_base.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6n_base.py	/^        type='EfficientRep',$/;"	v
+type	configs/base/yolov6n_base.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/base/yolov6n_base.py	/^    type='YOLOv6n_base',$/;"	v
+type	configs/base/yolov6n_base_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6n_base_finetune.py	/^        type='EfficientRep',$/;"	v
+type	configs/base/yolov6n_base_finetune.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/base/yolov6n_base_finetune.py	/^    type='YOLOv6n_base',$/;"	v
+type	configs/base/yolov6s_base.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/base/yolov6s_base.py	/^        type='CSPRepBiFPANNeck',#CSPRepPANNeck$/;"	v
+type	configs/base/yolov6s_base.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6s_base.py	/^    type='YOLOv6s_base',$/;"	v
+type	configs/base/yolov6s_base_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/base/yolov6s_base_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/base/yolov6s_base_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/base/yolov6s_base_finetune.py	/^    type='YOLOv6s_base',$/;"	v
+type	configs/experiment/yolov6n_with_eval_params.py	/^        type='EffiDeHead',$/;"	v
+type	configs/experiment/yolov6n_with_eval_params.py	/^        type='EfficientRep',$/;"	v
+type	configs/experiment/yolov6n_with_eval_params.py	/^        type='RepPANNeck',$/;"	v
+type	configs/experiment/yolov6n_with_eval_params.py	/^    type='YOLOv6n',$/;"	v
+type	configs/experiment/yolov6s_csp_scaled.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/experiment/yolov6s_csp_scaled.py	/^        type='CSPRepPANNeck',$/;"	v
+type	configs/experiment/yolov6s_csp_scaled.py	/^        type='EffiDeHead',$/;"	v
+type	configs/experiment/yolov6s_csp_scaled.py	/^    type='YOLOv6s_csp',$/;"	v
+type	configs/experiment/yolov6t.py	/^        type='EffiDeHead',$/;"	v
+type	configs/experiment/yolov6t.py	/^        type='EfficientRep',$/;"	v
+type	configs/experiment/yolov6t.py	/^        type='RepPANNeck',$/;"	v
+type	configs/experiment/yolov6t.py	/^    type='YOLOv6t',$/;"	v
+type	configs/experiment/yolov6t_csp_scaled.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/experiment/yolov6t_csp_scaled.py	/^        type='CSPRepPANNeck',$/;"	v
+type	configs/experiment/yolov6t_csp_scaled.py	/^        type='EffiDeHead',$/;"	v
+type	configs/experiment/yolov6t_csp_scaled.py	/^    type='YOLOv6n_csp',$/;"	v
+type	configs/experiment/yolov6t_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/experiment/yolov6t_finetune.py	/^        type='EfficientRep',$/;"	v
+type	configs/experiment/yolov6t_finetune.py	/^        type='RepPANNeck',$/;"	v
+type	configs/experiment/yolov6t_finetune.py	/^    type='YOLOv6t',$/;"	v
+type	configs/mbla/yolov6l_mbla.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6l_mbla.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6l_mbla.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6l_mbla.py	/^    type='YOLOv6l_mbla',$/;"	v
+type	configs/mbla/yolov6l_mbla_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6l_mbla_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6l_mbla_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6l_mbla_finetune.py	/^    type='YOLOv6l_mbla',$/;"	v
+type	configs/mbla/yolov6m_mbla.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6m_mbla.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6m_mbla.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6m_mbla.py	/^    type='YOLOv6m_mbla',$/;"	v
+type	configs/mbla/yolov6m_mbla_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6m_mbla_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6m_mbla_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6m_mbla_finetune.py	/^    type='YOLOv6m_mbla',$/;"	v
+type	configs/mbla/yolov6s_mbla.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6s_mbla.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6s_mbla.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6s_mbla.py	/^    type='YOLOv6s_mbla',$/;"	v
+type	configs/mbla/yolov6s_mbla_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6s_mbla_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6s_mbla_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6s_mbla_finetune.py	/^    type='YOLOv6s_mbla',$/;"	v
+type	configs/mbla/yolov6x_mbla.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6x_mbla.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6x_mbla.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6x_mbla.py	/^    type='YOLOv6x_mbla',$/;"	v
+type	configs/mbla/yolov6x_mbla_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/mbla/yolov6x_mbla_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/mbla/yolov6x_mbla_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/mbla/yolov6x_mbla_finetune.py	/^    type='YOLOv6x_mbla',$/;"	v
+type	configs/qarepvgg/yolov6m_qa.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/qarepvgg/yolov6m_qa.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/qarepvgg/yolov6m_qa.py	/^        type='EffiDeHead',$/;"	v
+type	configs/qarepvgg/yolov6m_qa.py	/^    type='YOLOv6m',$/;"	v
+type	configs/qarepvgg/yolov6n_qa.py	/^        type='EffiDeHead',$/;"	v
+type	configs/qarepvgg/yolov6n_qa.py	/^        type='EfficientRep',$/;"	v
+type	configs/qarepvgg/yolov6n_qa.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/qarepvgg/yolov6n_qa.py	/^    type='YOLOv6n',$/;"	v
+type	configs/qarepvgg/yolov6s_qa.py	/^        type='EffiDeHead',$/;"	v
+type	configs/qarepvgg/yolov6s_qa.py	/^        type='EfficientRep',$/;"	v
+type	configs/qarepvgg/yolov6s_qa.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/qarepvgg/yolov6s_qa.py	/^    type='YOLOv6s',$/;"	v
+type	configs/repopt/yolov6_tiny_hs.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6_tiny_hs.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6_tiny_hs.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6_tiny_hs.py	/^    type='YOLOv6t',$/;"	v
+type	configs/repopt/yolov6_tiny_opt.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6_tiny_opt.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6_tiny_opt.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6_tiny_opt.py	/^    type='YOLOv6t',$/;"	v
+type	configs/repopt/yolov6_tiny_opt_qat.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6_tiny_opt_qat.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6_tiny_opt_qat.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6_tiny_opt_qat.py	/^    type='YOLOv6t',$/;"	v
+type	configs/repopt/yolov6n_hs.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6n_hs.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6n_hs.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6n_hs.py	/^    type='YOLOv6n',$/;"	v
+type	configs/repopt/yolov6n_opt.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6n_opt.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6n_opt.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6n_opt.py	/^    type='YOLOv6n',$/;"	v
+type	configs/repopt/yolov6n_opt_qat.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6n_opt_qat.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6n_opt_qat.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6n_opt_qat.py	/^    type='YOLOv6n',$/;"	v
+type	configs/repopt/yolov6s_hs.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6s_hs.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6s_hs.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6s_hs.py	/^    type='YOLOv6s',$/;"	v
+type	configs/repopt/yolov6s_opt.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6s_opt.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6s_opt.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6s_opt.py	/^    type='YOLOv6s',$/;"	v
+type	configs/repopt/yolov6s_opt_qat.py	/^        type='EffiDeHead',$/;"	v
+type	configs/repopt/yolov6s_opt_qat.py	/^        type='EfficientRep',$/;"	v
+type	configs/repopt/yolov6s_opt_qat.py	/^        type='RepPANNeck',$/;"	v
+type	configs/repopt/yolov6s_opt_qat.py	/^    type='YOLOv6s',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l.py	/^        type='Lite_EffiBackbone',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l.py	/^        type='Lite_EffiNeck',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l.py	/^        type='Lite_EffideHead',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l.py	/^    type='YOLOv6-lite-l',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        type='Lite_EffiBackbone',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        type='Lite_EffiNeck',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        type='Lite_EffideHead',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    type='YOLOv6-lite-l',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m.py	/^        type='Lite_EffiBackbone',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m.py	/^        type='Lite_EffiNeck',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m.py	/^        type='Lite_EffideHead',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m.py	/^    type='YOLOv6-lite-m',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        type='Lite_EffiBackbone',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        type='Lite_EffiNeck',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        type='Lite_EffideHead',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    type='YOLOv6-lite-m',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s.py	/^        type='Lite_EffiBackbone',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s.py	/^        type='Lite_EffiNeck',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s.py	/^        type='Lite_EffideHead',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s.py	/^    type='YOLOv6-lite-s',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        type='Lite_EffiBackbone',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        type='Lite_EffiNeck',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        type='Lite_EffideHead',$/;"	v
+type	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    type='YOLOv6-lite-s',$/;"	v
+type	configs/yolov6l.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/yolov6l.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/yolov6l.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6l.py	/^    type='YOLOv6l',$/;"	v
+type	configs/yolov6l6.py	/^        type='CSPBepBackbone_P6',$/;"	v
+type	configs/yolov6l6.py	/^        type='CSPRepBiFPANNeck_P6',$/;"	v
+type	configs/yolov6l6.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6l6.py	/^    type='YOLOv6l6',$/;"	v
+type	configs/yolov6l6_finetune.py	/^        type='CSPBepBackbone_P6',$/;"	v
+type	configs/yolov6l6_finetune.py	/^        type='CSPRepBiFPANNeck_P6',$/;"	v
+type	configs/yolov6l6_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6l6_finetune.py	/^    type='YOLOv6l6',$/;"	v
+type	configs/yolov6l_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/yolov6l_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/yolov6l_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6l_finetune.py	/^    type='YOLOv6l',$/;"	v
+type	configs/yolov6m.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/yolov6m.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/yolov6m.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6m.py	/^    type='YOLOv6m',$/;"	v
+type	configs/yolov6m6.py	/^        type='CSPBepBackbone_P6',$/;"	v
+type	configs/yolov6m6.py	/^        type='CSPRepBiFPANNeck_P6',$/;"	v
+type	configs/yolov6m6.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6m6.py	/^    type='YOLOv6m6',$/;"	v
+type	configs/yolov6m6_finetune.py	/^        type='CSPBepBackbone_P6',$/;"	v
+type	configs/yolov6m6_finetune.py	/^        type='CSPRepBiFPANNeck_P6',$/;"	v
+type	configs/yolov6m6_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6m6_finetune.py	/^    type='YOLOv6m6',$/;"	v
+type	configs/yolov6m_finetune.py	/^        type='CSPBepBackbone',$/;"	v
+type	configs/yolov6m_finetune.py	/^        type='CSPRepBiFPANNeck',$/;"	v
+type	configs/yolov6m_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6m_finetune.py	/^    type='YOLOv6m',$/;"	v
+type	configs/yolov6n.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6n.py	/^        type='EfficientRep',$/;"	v
+type	configs/yolov6n.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/yolov6n.py	/^    type='YOLOv6n',$/;"	v
+type	configs/yolov6n6.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6n6.py	/^        type='EfficientRep6',$/;"	v
+type	configs/yolov6n6.py	/^        type='RepBiFPANNeck6',$/;"	v
+type	configs/yolov6n6.py	/^    type='YOLOv6n6',$/;"	v
+type	configs/yolov6n6_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6n6_finetune.py	/^        type='EfficientRep6',$/;"	v
+type	configs/yolov6n6_finetune.py	/^        type='RepBiFPANNeck6',$/;"	v
+type	configs/yolov6n6_finetune.py	/^    type='YOLOv6n6',$/;"	v
+type	configs/yolov6n_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6n_finetune.py	/^        type='EfficientRep',$/;"	v
+type	configs/yolov6n_finetune.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/yolov6n_finetune.py	/^    type='YOLOv6n',$/;"	v
+type	configs/yolov6s.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6s.py	/^        type='EfficientRep',$/;"	v
+type	configs/yolov6s.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/yolov6s.py	/^    type='YOLOv6s',$/;"	v
+type	configs/yolov6s6.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6s6.py	/^        type='EfficientRep6',$/;"	v
+type	configs/yolov6s6.py	/^        type='RepBiFPANNeck6',$/;"	v
+type	configs/yolov6s6.py	/^    type='YOLOv6s6',$/;"	v
+type	configs/yolov6s6_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6s6_finetune.py	/^        type='EfficientRep6',$/;"	v
+type	configs/yolov6s6_finetune.py	/^        type='RepBiFPANNeck6',$/;"	v
+type	configs/yolov6s6_finetune.py	/^    type='YOLOv6s6',$/;"	v
+type	configs/yolov6s_finetune.py	/^        type='EffiDeHead',$/;"	v
+type	configs/yolov6s_finetune.py	/^        type='EfficientRep',$/;"	v
+type	configs/yolov6s_finetune.py	/^        type='RepBiFPANNeck',$/;"	v
+type	configs/yolov6s_finetune.py	/^    type='YOLOv6s',$/;"	v
+unified_channels	configs/yolov6_lite/yolov6_lite_l.py	/^        unified_channels=96$/;"	v
+unified_channels	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        unified_channels=96$/;"	v
+unified_channels	configs/yolov6_lite/yolov6_lite_m.py	/^        unified_channels=96$/;"	v
+unified_channels	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        unified_channels=96$/;"	v
+unified_channels	configs/yolov6_lite/yolov6_lite_s.py	/^        unified_channels=96$/;"	v
+unified_channels	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        unified_channels=96$/;"	v
+update	yolov6/core/inferer.py	/^    def update(self, duration: float):$/;"	m	class:CalcFPS
+update	yolov6/utils/ema.py	/^    def update(self, model):$/;"	m	class:ModelEMA
+update_attr	yolov6/utils/ema.py	/^    def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):$/;"	m	class:ModelEMA
+update_optimizer	yolov6/core/engine.py	/^    def update_optimizer(self):$/;"	m	class:Trainer
+upsample_enable_quant	yolov6/models/reppan.py	/^    def upsample_enable_quant(self, num_bits, calib_method):$/;"	m	class:RepPANNeck
+use_dfl	configs/base/yolov6l_base.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/base/yolov6l_base_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/base/yolov6m_base.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/base/yolov6m_base_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/base/yolov6n_base.py	/^        use_dfl=True, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/base/yolov6n_base_finetune.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/base/yolov6s_base.py	/^        use_dfl=True, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/base/yolov6s_base_finetune.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/experiment/yolov6n_with_eval_params.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/experiment/yolov6s_csp_scaled.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/experiment/yolov6t.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/experiment/yolov6t_csp_scaled.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/experiment/yolov6t_finetune.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/mbla/yolov6l_mbla.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6l_mbla_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6m_mbla.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6m_mbla_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6s_mbla.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6s_mbla_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6x_mbla.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/mbla/yolov6x_mbla_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/qarepvgg/yolov6m_qa.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/qarepvgg/yolov6n_qa.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/qarepvgg/yolov6s_qa.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/repopt/yolov6_tiny_hs.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6_tiny_opt.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6_tiny_opt_qat.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6n_hs.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6n_opt.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6n_opt_qat.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6s_hs.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6s_opt.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/repopt/yolov6s_opt_qat.py	/^        use_dfl = False,$/;"	v
+use_dfl	configs/yolov6_lite/yolov6_lite_l.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6_lite/yolov6_lite_m.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6_lite/yolov6_lite_s.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6l.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6l6.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6l6_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6l_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6m.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6m6.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6m6_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6m_finetune.py	/^        use_dfl=True,$/;"	v
+use_dfl	configs/yolov6n.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/yolov6n6.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6n6_finetune.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6n_finetune.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/yolov6s.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+use_dfl	configs/yolov6s6.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6s6_finetune.py	/^        use_dfl=False,$/;"	v
+use_dfl	configs/yolov6s_finetune.py	/^        use_dfl=False, # set to True if you want to further train with distillation$/;"	v
+verbose	configs/experiment/yolov6n_with_eval_params.py	/^    verbose=False,$/;"	v
+verbose	tools/partial_quantization/partial_quant.py	/^                          verbose=False,$/;"	v
+verbose	tools/qat/qat_export.py	/^                          verbose=False,$/;"	v
+video	deploy/ONNX/OpenCV/yolo_video.py	/^def video():$/;"	f
+vis	deploy/ONNX/OpenCV/yolox.py	/^    def vis(self, img, boxes, scores, cls_ids):$/;"	m	class:yolox
+visualize_detections	hubconf.py	/^def visualize_detections(image,$/;"	f
+wandh	deploy/ONNX/export_onnx.py	/^                wandh = 'x'.join(list(map(str,args.img_size)))$/;"	v
+warmup_bias_lr	configs/base/yolov6l_base.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/base/yolov6l_base_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/base/yolov6m_base.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/base/yolov6m_base_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/base/yolov6n_base.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/base/yolov6n_base_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/base/yolov6s_base.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/base/yolov6s_base_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/experiment/yolov6n_with_eval_params.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/experiment/yolov6s_csp_scaled.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/experiment/yolov6t.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/experiment/yolov6t_csp_scaled.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/experiment/yolov6t_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/mbla/yolov6l_mbla.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/mbla/yolov6l_mbla_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/mbla/yolov6m_mbla.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/mbla/yolov6m_mbla_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/mbla/yolov6s_mbla.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/mbla/yolov6s_mbla_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/mbla/yolov6x_mbla.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/mbla/yolov6x_mbla_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/qarepvgg/yolov6m_qa.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/qarepvgg/yolov6n_qa.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/qarepvgg/yolov6s_qa.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6_tiny_hs.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6_tiny_opt.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6_tiny_opt_qat.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6n_hs.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6n_opt.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6n_opt_qat.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6s_hs.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6s_opt.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/repopt/yolov6s_opt_qat.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6_lite/yolov6_lite_l.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6_lite/yolov6_lite_m.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6_lite/yolov6_lite_s.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6l.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6l6.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6l6_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6l_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6m.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6m6.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6m6_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6m_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6n.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6n6.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6n6_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6n_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6s.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6s6.py	/^    warmup_bias_lr=0.1$/;"	v
+warmup_bias_lr	configs/yolov6s6_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_bias_lr	configs/yolov6s_finetune.py	/^    warmup_bias_lr=0.05$/;"	v
+warmup_epochs	configs/base/yolov6l_base.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/base/yolov6l_base_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/base/yolov6m_base.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/base/yolov6m_base_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/base/yolov6n_base.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/base/yolov6n_base_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/base/yolov6s_base.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/base/yolov6s_base_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/experiment/yolov6n_with_eval_params.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/experiment/yolov6s_csp_scaled.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/experiment/yolov6t.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/experiment/yolov6t_csp_scaled.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/experiment/yolov6t_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6l_mbla.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6l_mbla_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6m_mbla.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6m_mbla_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6s_mbla.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6s_mbla_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6x_mbla.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/mbla/yolov6x_mbla_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/qarepvgg/yolov6m_qa.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/qarepvgg/yolov6n_qa.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/qarepvgg/yolov6s_qa.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6_tiny_hs.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6_tiny_opt.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6_tiny_opt_qat.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6n_hs.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6n_opt.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6n_opt_qat.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6s_hs.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6s_opt.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/repopt/yolov6s_opt_qat.py	/^    warmup_epochs=3,$/;"	v
+warmup_epochs	configs/yolov6_lite/yolov6_lite_l.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6_lite/yolov6_lite_m.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6_lite/yolov6_lite_s.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6l.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6l6.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6l6_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6l_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6m.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6m6.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6m6_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6m_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6n.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6n6.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6n6_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6n_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6s.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6s6.py	/^    warmup_epochs=3.0,$/;"	v
+warmup_epochs	configs/yolov6s6_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_epochs	configs/yolov6s_finetune.py	/^    warmup_epochs=2.0,$/;"	v
+warmup_momentum	configs/base/yolov6l_base.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/base/yolov6l_base_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/base/yolov6m_base.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/base/yolov6m_base_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/base/yolov6n_base.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/base/yolov6n_base_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/base/yolov6s_base.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/base/yolov6s_base_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/experiment/yolov6n_with_eval_params.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/experiment/yolov6s_csp_scaled.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/experiment/yolov6t.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/experiment/yolov6t_csp_scaled.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/experiment/yolov6t_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/mbla/yolov6l_mbla.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/mbla/yolov6l_mbla_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/mbla/yolov6m_mbla.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/mbla/yolov6m_mbla_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/mbla/yolov6s_mbla.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/mbla/yolov6s_mbla_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/mbla/yolov6x_mbla.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/mbla/yolov6x_mbla_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/qarepvgg/yolov6m_qa.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/qarepvgg/yolov6n_qa.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/qarepvgg/yolov6s_qa.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6_tiny_hs.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6_tiny_opt.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6_tiny_opt_qat.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6n_hs.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6n_opt.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6n_opt_qat.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6s_hs.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6s_opt.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/repopt/yolov6s_opt_qat.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6_lite/yolov6_lite_l.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6_lite/yolov6_lite_m.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6_lite/yolov6_lite_s.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6l.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6l6.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6l6_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6l_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6m.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6m6.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6m6_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6m_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6n.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6n6.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6n6_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6n_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6s.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6s6.py	/^    warmup_momentum=0.8,$/;"	v
+warmup_momentum	configs/yolov6s6_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warmup_momentum	configs/yolov6s_finetune.py	/^    warmup_momentum=0.5,$/;"	v
+warn	deploy/NCNN/Android/gradlew	/^warn () {$/;"	f
+weight_decay	configs/base/yolov6l_base.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/base/yolov6l_base_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/base/yolov6m_base.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/base/yolov6m_base_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/base/yolov6n_base.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/base/yolov6n_base_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/base/yolov6s_base.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/base/yolov6s_base_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/experiment/yolov6n_with_eval_params.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/experiment/yolov6s_csp_scaled.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/experiment/yolov6t.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/experiment/yolov6t_csp_scaled.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/experiment/yolov6t_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/mbla/yolov6l_mbla.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/mbla/yolov6l_mbla_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/mbla/yolov6m_mbla.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/mbla/yolov6m_mbla_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/mbla/yolov6s_mbla.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/mbla/yolov6s_mbla_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/mbla/yolov6x_mbla.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/mbla/yolov6x_mbla_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/qarepvgg/yolov6m_qa.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/qarepvgg/yolov6n_qa.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/qarepvgg/yolov6s_qa.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6_tiny_hs.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6_tiny_opt.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6_tiny_opt_qat.py	/^    weight_decay=0.00005,$/;"	v
+weight_decay	configs/repopt/yolov6n_hs.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6n_opt.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6n_opt_qat.py	/^    weight_decay=0.00005,$/;"	v
+weight_decay	configs/repopt/yolov6s_hs.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6s_opt.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/repopt/yolov6s_opt_qat.py	/^    weight_decay=0.00005,$/;"	v
+weight_decay	configs/yolov6_lite/yolov6_lite_l.py	/^    weight_decay=0.00004,$/;"	v
+weight_decay	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6_lite/yolov6_lite_m.py	/^    weight_decay=0.00004,$/;"	v
+weight_decay	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6_lite/yolov6_lite_s.py	/^    weight_decay=0.00004,$/;"	v
+weight_decay	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6l.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6l6.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6l6_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6l_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6m.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6m6.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6m6_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6m_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6n.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6n6.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6n6_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6n_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6s.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6s6.py	/^    weight_decay=0.0005,$/;"	v
+weight_decay	configs/yolov6s6_finetune.py	/^    weight_decay=0.00036,$/;"	v
+weight_decay	configs/yolov6s_finetune.py	/^    weight_decay=0.00036,$/;"	v
+width_multiple	configs/base/yolov6l_base.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/base/yolov6l_base_finetune.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/base/yolov6m_base.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/base/yolov6m_base_finetune.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/base/yolov6n_base.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/base/yolov6n_base_finetune.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/base/yolov6s_base.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/base/yolov6s_base_finetune.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/experiment/yolov6n_with_eval_params.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/experiment/yolov6s_csp_scaled.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/experiment/yolov6t.py	/^    width_multiple=0.375,$/;"	v
+width_multiple	configs/experiment/yolov6t_csp_scaled.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/experiment/yolov6t_finetune.py	/^    width_multiple=0.375,$/;"	v
+width_multiple	configs/mbla/yolov6l_mbla.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/mbla/yolov6l_mbla_finetune.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/mbla/yolov6m_mbla.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/mbla/yolov6m_mbla_finetune.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/mbla/yolov6s_mbla.py	/^    width_multiple=0.5,$/;"	v
+width_multiple	configs/mbla/yolov6s_mbla_finetune.py	/^    width_multiple=0.5,$/;"	v
+width_multiple	configs/mbla/yolov6x_mbla.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/mbla/yolov6x_mbla_finetune.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/qarepvgg/yolov6m_qa.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/qarepvgg/yolov6n_qa.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/qarepvgg/yolov6s_qa.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/repopt/yolov6_tiny_hs.py	/^    width_multiple=0.375,$/;"	v
+width_multiple	configs/repopt/yolov6_tiny_opt.py	/^    width_multiple=0.375,$/;"	v
+width_multiple	configs/repopt/yolov6_tiny_opt_qat.py	/^    width_multiple=0.375,$/;"	v
+width_multiple	configs/repopt/yolov6n_hs.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/repopt/yolov6n_opt.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/repopt/yolov6n_opt_qat.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/repopt/yolov6s_hs.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/repopt/yolov6s_opt.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/repopt/yolov6s_opt_qat.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/yolov6_lite/yolov6_lite_l.py	/^    width_multiple=1.5,$/;"	v
+width_multiple	configs/yolov6_lite/yolov6_lite_l_finetune.py	/^    width_multiple=1.5,$/;"	v
+width_multiple	configs/yolov6_lite/yolov6_lite_m.py	/^    width_multiple=1.1,$/;"	v
+width_multiple	configs/yolov6_lite/yolov6_lite_m_finetune.py	/^    width_multiple=1.1,$/;"	v
+width_multiple	configs/yolov6_lite/yolov6_lite_s.py	/^    width_multiple=0.7,$/;"	v
+width_multiple	configs/yolov6_lite/yolov6_lite_s_finetune.py	/^    width_multiple=0.7,$/;"	v
+width_multiple	configs/yolov6l.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/yolov6l6.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/yolov6l6_finetune.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/yolov6l_finetune.py	/^    width_multiple=1.0,$/;"	v
+width_multiple	configs/yolov6m.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/yolov6m6.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/yolov6m6_finetune.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/yolov6m_finetune.py	/^    width_multiple=0.75,$/;"	v
+width_multiple	configs/yolov6n.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/yolov6n6.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/yolov6n6_finetune.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/yolov6n_finetune.py	/^    width_multiple=0.25,$/;"	v
+width_multiple	configs/yolov6s.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/yolov6s6.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/yolov6s6_finetune.py	/^    width_multiple=0.50,$/;"	v
+width_multiple	configs/yolov6s_finetune.py	/^    width_multiple=0.50,$/;"	v
+win	deploy/NCNN/Android/app/src/main/jni/ndkcamera.h	/^    ANativeWindow* win;$/;"	m	class:NdkCameraWindow
+window_name	deploy/ONNX/OpenCV/yolo.py	/^	window_name = os.path.splitext(os.path.basename(model_path))[0]$/;"	v
+window_name	deploy/ONNX/OpenCV/yolox.py	/^    window_name = os.path.splitext(os.path.basename(args.model))[0]$/;"	v	class:yolox
+workspace_pool_allocator	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    ncnn::PoolAllocator workspace_pool_allocator;$/;"	m	class:Yolo
+write_calibration_cache	deploy/TensorRT/calibrator.py	/^    def write_calibration_cache(self, cache):$/;"	m	class:Calibrator
+write_calibration_cache	tools/quantization/tensorrt/post_training/Calibrator.py	/^    def write_calibration_cache(self, cache):$/;"	m	class:ImageCalibrator
+write_tbimg	yolov6/utils/events.py	/^def write_tbimg(tblogger, imgs, step, type='train'):$/;"	f
+write_tblog	yolov6/utils/events.py	/^def write_tblog(tblogger, epoch, results, lrs, losses):$/;"	f
+xywh2xyxy	deploy/TensorRT/Processor.py	/^    def xywh2xyxy(x):$/;"	m	class:Processor
+xywh2xyxy	deploy/TensorRT/tensorrt_processor.py	/^    def xywh2xyxy(x):$/;"	m	class:Processor
+xywh2xyxy	yolov6/utils/general.py	/^def xywh2xyxy(bboxes):$/;"	f
+xywh2xyxy	yolov6/utils/nms.py	/^def xywh2xyxy(x):$/;"	f
+y	deploy/NCNN/export_torchscript.py	/^    y = model(img)  # dry run$/;"	v
+y	deploy/ONNX/export_onnx.py	/^    y = model(img)  # dry run$/;"	v
+y	deploy/OpenVINO/export_openvino.py	/^    y = model(img)  # dry run$/;"	v
+yolo	deploy/NCNN/Android/app/src/main/jni/yolo.h	/^    ncnn::Net yolo;$/;"	m	class:Yolo
+yolov6_decode	deploy/NCNN/infer-ncnn-model.py	/^def yolov6_decode(feats: List[ndarray],$/;"	f
+yolov6_evaler	tools/partial_quantization/partial_quant.py	/^    yolov6_evaler = EvalerWrapper(eval_cfg=load_yaml(args.eval_yaml))$/;"	v
+yolov6_evaler	tools/partial_quantization/sensitivity_analyse.py	/^    yolov6_evaler = EvalerWrapper(eval_cfg=load_yaml(args.eval_yaml))$/;"	v
+yolov6_evaler	tools/qat/qat_export.py	/^    yolov6_evaler = EvalerWrapper(eval_cfg=load_yaml(args.eval_yaml))$/;"	v
+yolov6l	configs/experiment/eval_640_repro.py	/^    yolov6l = dict($/;"	v
+yolov6l	hubconf.py	/^def yolov6l(class_names=CLASS_NAMES, device=DEVICE, img_size=640, conf_thres=0.25, iou_thres=0.45, max_det=1000):$/;"	f
+yolov6l6	configs/experiment/eval_640_repro.py	/^    yolov6l6 = dict($/;"	v
+yolov6l_mbla	configs/experiment/eval_640_repro.py	/^    yolov6l_mbla = dict($/;"	v
+yolov6l_relu	configs/experiment/eval_640_repro.py	/^    yolov6l_relu = dict($/;"	v
+yolov6m	configs/experiment/eval_640_repro.py	/^    yolov6m = dict($/;"	v
+yolov6m	hubconf.py	/^def yolov6m(class_names=CLASS_NAMES, device=DEVICE, img_size=640, conf_thres=0.25, iou_thres=0.45, max_det=1000):$/;"	f
+yolov6m6	configs/experiment/eval_640_repro.py	/^    yolov6m6 = dict($/;"	v
+yolov6m_mbla	configs/experiment/eval_640_repro.py	/^    yolov6m_mbla = dict($/;"	v
+yolov6n	configs/experiment/eval_640_repro.py	/^    yolov6n = dict($/;"	v
+yolov6n	hubconf.py	/^def yolov6n(class_names=CLASS_NAMES, device=DEVICE, img_size=640, conf_thres=0.25, iou_thres=0.45, max_det=1000):$/;"	f
+yolov6n6	configs/experiment/eval_640_repro.py	/^    yolov6n6 = dict($/;"	v
+yolov6ncnn	deploy/NCNN/Android/app/src/main/java/com/tencent/yolov6ncnn/MainActivity.java	/^    private Yolov6Ncnn yolov6ncnn = new Yolov6Ncnn();$/;"	f	class:MainActivity	file:
+yolov6s	configs/experiment/eval_640_repro.py	/^    yolov6s = dict($/;"	v
+yolov6s	hubconf.py	/^def yolov6s(class_names=CLASS_NAMES, device=DEVICE, img_size=640, conf_thres=0.25, iou_thres=0.45, max_det=1000):$/;"	f
+yolov6s6	configs/experiment/eval_640_repro.py	/^    yolov6s6 = dict($/;"	v
+yolov6s_mbla	configs/experiment/eval_640_repro.py	/^    yolov6s_mbla = dict($/;"	v
+yolov6t	configs/experiment/eval_640_repro.py	/^    yolov6t = dict($/;"	v
+yolov6x_mbla	configs/experiment/eval_640_repro.py	/^    yolov6x_mbla = dict($/;"	v
+yolox	deploy/ONNX/OpenCV/yolox.py	/^class yolox():$/;"	c
+yolox	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^class yolox$/;"	c	file:
+yolox	deploy/ONNX/OpenCV/yolox/yolox.cpp	/^yolox::yolox(string modelpath, float confThreshold, float nmsThreshold, string classesFile)$/;"	f	class:yolox
+zero_scale_fix	tools/qat/qat_export.py	/^def zero_scale_fix(model, device):$/;"	f
+~LogStreamConsumerBuffer	deploy/TensorRT/logging.h	/^    ~LogStreamConsumerBuffer()$/;"	f	class:LogStreamConsumerBuffer
+~NdkCamera	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^NdkCamera::~NdkCamera()$/;"	f	class:NdkCamera
+~NdkCameraWindow	deploy/NCNN/Android/app/src/main/jni/ndkcamera.cpp	/^NdkCameraWindow::~NdkCameraWindow()$/;"	f	class:NdkCameraWindow

--- a/yolov6/utils/general.py
+++ b/yolov6/utils/general.py
@@ -8,6 +8,7 @@ import requests
 import pkg_resources as pkg
 from pathlib import Path
 from yolov6.utils.events import LOGGER
+from pycocotools.coco import COCO
 
 def increment_name(path):
     '''increase save directory's id'''
@@ -125,3 +126,16 @@ def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=Fals
         info = f'⚠️ {name}{minimum} is required by YOLOv6, but {name}{current} is currently installed'
         assert result, info  # assert minimum version requirement
     return result
+
+def filename2imgid(anno_path):
+    coco = COCO(anno_path)
+
+    # Create a mapping dictionary of file names to image_id
+    filename_to_image_id = {}
+    image_ids = coco.getImgIds()
+    for image_id in image_ids:
+        image_info = coco.loadImgs(image_id)[0]
+        filename = image_info['file_name']  # The file name of image
+        filename_to_image_id[filename] = image_id
+        
+    return filename_to_image_id


### PR DESCRIPTION
When our custom dataset label is not named after the coco dataset file, we are likely to trigger the following bugs when we run the eval script: AssertionError: Results do not correspond to current coco set.
The reasons that trigger this bug are: 1. The eval func could not map the image name to image id; 2. The coco api could not compare the type str with type int.
So we should change the evaluation fucation of yolov6 and the coco api, the corresponding changes of evaluation function is changed in the branch yolov6-eval. In the end, we should add  one line of code in coco api after the line of the aforementioned assertionerror like annsImgIds = list(map(int, annsImgIds)).