### PR TITLE
fix a bug cause: onnxruntime.capi.onnxruntime_pybind11_state.Fail

### DIFF
--- a/yolov6/models/end2end.py
+++ b/yolov6/models/end2end.py
@@ -171,7 +171,7 @@ class ONNX_ORT(nn.Module):
         batched_dets = batched_dets.where((batch_inds == batch_template.unsqueeze(1)).unsqueeze(-1),batched_dets.new_zeros(1))
 
         batched_labels = cls_inds.unsqueeze(0).repeat(batch, 1)
-        batched_labels = batched_labels.where((batch_inds == batch_template.unsqueeze(1)),batched_labels.new_ones(1) * -1)
+        batched_labels = batched_labels.where((batch_inds == batch_template.unsqueeze(1)),batched_labels.new_ones(1, dtype=batched_labels.dtype) * -1)
 
         N = batched_dets.shape[0]
 

--- a/yolov6/models/losses/loss.py
+++ b/yolov6/models/losses/loss.py
@@ -205,7 +205,7 @@ class VarifocalLoss(nn.Module):
     def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
 
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast('cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
 
         return loss


### PR DESCRIPTION
fix a bug which may cause err: onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from *.onnx failed:Type Error: Type parameter (T) of Optype (Where) bound to different types (tensor(int64) and tensor(float) in node (/end2end/Where_1).
修复了一个会导致`onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from *.onnx failed:Type Error: Type parameter (T) of Optype (Where) bound to different types (tensor(int64) and tensor(float) in node (/end2end/Where_1).`的bug。

原因是在导出到onnx时，batched_labels.new_ones应该创建一个与自身相同类型的tensor（在python中运行时确实如此），然而实际导出后创建的tensor类型（float）与batched_labels（int）不一致，造成了运行时err。

在旧版本中并没有出现这个问题（暂时不清楚是由于旧版pytorch没有这个导出bug还是onnx的where能够跨类型使用）
出现这个bug的版本是：
pytorch 2.1.0a0+41361538.nv23.6+onnxruntime-gpu 1.17.0

修改前：
![图片](https://github.com/meituan/YOLOv6/assets/73748897/8e48a52c-308c-4455-99d0-c77352b8b67e)


修改后：
![图片](https://github.com/meituan/YOLOv6/assets/73748897/383fa94c-263f-48e9-890f-ed476c32dd9a)


注意：在下面2个issue中，都有类似的err，其中一条是由于seg不支持end2end导出，另一条是由于此bug而产生，虽然issue已经被关闭，然而问题的根源并没有被解决。
[#1021 ](https://github.com/meituan/YOLOv6/issues/1021#issue-2137868300)
https://github.com/meituan/YOLOv6/issues/1013#issue-2111373801