### PR TITLE
Update deprecated torch.cuda.amp API calls for PyTorch 2.0+ compatibility #1077

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ venv.bak/
 *.onnx
 *.pt
 *.engine
+
+# custom training data
+wearfits-training/

--- a/wearfits-training
+++ b/wearfits-training
@@ -1,0 +1,1 @@
+C:/AI/wearfits-training

--- a/yolov6/core/engine.py
+++ b/yolov6/core/engine.py
@@ -12,7 +12,7 @@ import cv2
 import numpy as np
 import math
 import torch
-from torch.cuda import amp
+from torch import amp
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.tensorboard import SummaryWriter
 
@@ -147,7 +147,7 @@ class Trainer:
             write_tbimg(self.tblogger, self.vis_train_batch, self.step + self.max_stepnum * self.epoch, type='train')
 
         # forward
-        with amp.autocast(enabled=self.device != 'cpu'):
+        with amp.autocast('cuda', enabled=self.device != 'cpu'):
             _, _, batch_height, batch_width = images.shape
             preds, s_featmaps = self.model(images)
             if self.args.distill:
@@ -275,7 +275,7 @@ class Trainer:
         self.warmup_stepnum = max(round(self.cfg.solver.warmup_epochs * self.max_stepnum), 1000) if self.args.quant is False else 0
         self.scheduler.last_epoch = self.start_epoch - 1
         self.last_opt_step = -1
-        self.scaler = amp.GradScaler(enabled=self.device != 'cpu')
+        self.scaler = amp.GradScaler('cuda', enabled=self.device != 'cpu')
 
         self.best_ap, self.ap = 0.0, 0.0
         self.best_stop_strong_aug_ap = 0.0

--- a/yolov6/core/engine.py
+++ b/yolov6/core/engine.py
@@ -147,7 +147,7 @@ class Trainer:
             write_tbimg(self.tblogger, self.vis_train_batch, self.step + self.max_stepnum * self.epoch, type='train')
 
         # forward
-        with amp.autocast('cuda', enabled=self.device != 'cpu'):
+        with amp.autocast(device_type='cuda', enabled=self.device != 'cpu'):
             _, _, batch_height, batch_width = images.shape
             preds, s_featmaps = self.model(images)
             if self.args.distill:

--- a/yolov6/core/engine.py
+++ b/yolov6/core/engine.py
@@ -12,7 +12,7 @@ import cv2
 import numpy as np
 import math
 import torch
-from torch.cuda import amp
+from torch import amp
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.tensorboard import SummaryWriter
 

--- a/yolov6/core/engine.py
+++ b/yolov6/core/engine.py
@@ -147,7 +147,7 @@ class Trainer:
             write_tbimg(self.tblogger, self.vis_train_batch, self.step + self.max_stepnum * self.epoch, type='train')
 
         # forward
-        with amp.autocast(enabled=self.device != 'cpu'):
+        with amp.autocast(device_type='cuda', enabled=self.device != 'cpu'):
             _, _, batch_height, batch_width = images.shape
             preds, s_featmaps = self.model(images)
             if self.args.distill:

--- a/yolov6/models/losses/loss.py
+++ b/yolov6/models/losses/loss.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import torch
+from torch import amp
 import torch.nn as nn
 import numpy as np
 import torch.nn.functional as F
@@ -205,7 +206,7 @@ class VarifocalLoss(nn.Module):
     def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
 
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with torch.cuda.amp.autocast(enabled=False):
+        with amp.autocast('cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
 
         return loss

--- a/yolov6/models/losses/loss.py
+++ b/yolov6/models/losses/loss.py
@@ -206,7 +206,7 @@ class VarifocalLoss(nn.Module):
     def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
 
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with amp.autocast('cuda', enabled=False):
+        with amp.autocast(device_type='cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
 
         return loss

--- a/yolov6/models/losses/loss.py
+++ b/yolov6/models/losses/loss.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import torch
+from torch import amp
 import torch.nn as nn
 import numpy as np
 import torch.nn.functional as F
@@ -205,7 +206,7 @@ class VarifocalLoss(nn.Module):
     def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
 
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with torch.cuda.amp.autocast(enabled=False):
+        with amp.autocast(device_type='cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
 
         return loss

--- a/yolov6/models/losses/loss_distill.py
+++ b/yolov6/models/losses/loss_distill.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import torch
+from torch import amp
 import torch.nn as nn
 import numpy as np
 import torch.nn.functional as F
@@ -265,12 +266,10 @@ class VarifocalLoss(nn.Module):
     def __init__(self):
         super(VarifocalLoss, self).__init__()
 
-    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
-
+    def forward(self, pred_score, gt_score, label, alpha=0.75, gamma=2.0):
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with torch.cuda.amp.autocast(enabled=False):
+        with amp.autocast(device_type='cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
-
         return loss
 
 

--- a/yolov6/models/losses/loss_distill_ns.py
+++ b/yolov6/models/losses/loss_distill_ns.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import torch
+from torch import amp
 import torch.nn as nn
 import numpy as np
 import torch.nn.functional as F
@@ -245,12 +246,10 @@ class VarifocalLoss(nn.Module):
     def __init__(self):
         super(VarifocalLoss, self).__init__()
 
-    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
-
+    def forward(self, pred_score, gt_score, label, alpha=0.75, gamma=2.0):
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with torch.cuda.amp.autocast(enabled=False):
+        with amp.autocast(device_type='cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
-
         return loss
 
 

--- a/yolov6/models/losses/loss_fuseab.py
+++ b/yolov6/models/losses/loss_fuseab.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import torch
+from torch import amp
 import torch.nn as nn
 import numpy as np
 import torch.nn.functional as F
@@ -167,12 +168,10 @@ class VarifocalLoss(nn.Module):
     def __init__(self):
         super(VarifocalLoss, self).__init__()
 
-    def forward(self, pred_score,gt_score, label, alpha=0.75, gamma=2.0):
-
+    def forward(self, pred_score, gt_score, label, alpha=0.75, gamma=2.0):
         weight = alpha * pred_score.pow(gamma) * (1 - label) + gt_score * label
-        with torch.cuda.amp.autocast(enabled=False):
+        with amp.autocast(device_type='cuda', enabled=False):
             loss = (F.binary_cross_entropy(pred_score.float(), gt_score.float(), reduction='none') * weight).sum()
-
         return loss
 
 


### PR DESCRIPTION
This PR updates the deprecated `torch.cuda.amp` API calls to be compatible with PyTorch 2.0+. The changes include:

- Replace `torch.cuda.amp` with `torch.amp`
- Add device specification ('cuda') to `amp.autocast` and `GradScaler`
- Update imports to use `torch.amp` directly

These changes ensure compatibility with newer PyTorch versions while maintaining the same functionality. The updates affect:
- `yolov6/core/engine.py`
- `yolov6/models/losses/loss.py`

This addresses issue #1077.